### PR TITLE
Redesign:  Do not show transaction notifications when restoring from seed or file

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/Configuration.java
+++ b/common/src/main/java/org/dash/wallet/common/Configuration.java
@@ -73,6 +73,7 @@ public class Configuration {
     public final static String PREFS_LAST_UNLOCK_TIME = "last_unlock_time";
     private static final String PREFS_REMIND_ENABLE_FINGERPRINT = "remind_enable_fingerprint";
     public static final String PREFS_KEY_CAN_AUTO_LOCK = "can_auto_lock";
+    public static final String PREFS_RESTORING_BACKUP = "restoring_backup";
 
     private static final int PREFS_DEFAULT_BTC_SHIFT = 0;
     private static final int PREFS_DEFAULT_BTC_PRECISION = 4;
@@ -290,7 +291,14 @@ public class Configuration {
             prefs.edit().putInt(PREFS_KEY_BEST_CHAIN_HEIGHT_EVER, bestChainHeightEver).apply();
     }
 
-        public boolean getLastExchangeDirection() {
+    public boolean isRestoringBackup() {
+        return prefs.getBoolean(PREFS_RESTORING_BACKUP, false);
+    }
+
+    public void setRestoringBackup(final boolean isRestoringBackup) {
+        prefs.edit().putBoolean(PREFS_RESTORING_BACKUP, isRestoringBackup).apply();
+    }
+    public boolean getLastExchangeDirection() {
         return prefs.getBoolean(PREFS_KEY_LAST_EXCHANGE_DIRECTION, true);
     }
 

--- a/wallet/src/de/schildbach/wallet/ui/OnboardingViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/OnboardingViewModel.kt
@@ -58,6 +58,7 @@ class OnboardingViewModel(application: Application) : AndroidViewModel(applicati
         walletApplication.wallet = wallet
         log.info("successfully restored wallet from seed")
         walletApplication.configuration.disarmBackupSeedReminder()
+        walletApplication.configuration.setRestoringBackup(true)
         startActivityAction.call(SetPinActivity.createIntent(getApplication(), R.string.set_pin_restore_wallet))
     }
 }

--- a/wallet/src/de/schildbach/wallet/ui/RestoreWalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/RestoreWalletActivity.java
@@ -181,7 +181,7 @@ public final class RestoreWalletActivity extends AbstractWalletActivity
             final InputStream is = new ByteArrayInputStream(plainText);
 
             restoreWallet(WalletUtils.restoreWalletFromProtobufOrBase58(is, Constants.NETWORK_PARAMETERS));
-
+            application.getConfiguration().setRestoringBackup(true);
             log.info("successfully restored encrypted wallet from external source");
         } catch (final IOException x) {
             final DialogBuilder dialog = DialogBuilder.warn(this, R.string.import_export_keys_dialog_failure_title);

--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -676,6 +676,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
             @Override
             public void onRestoreWallet(Wallet wallet) {
                 restoreWallet(wallet);
+                application.getConfiguration().setRestoringBackup(true);
             }
 
             @Override


### PR DESCRIPTION
Expected Behavior:
- Don’t show notifications if rescanning the blockchain (current behavior)
- Don’t show notifications if restoring from a recovery phrase or backup file (until 1 day ago)
- Do show notifications on new transactions received while the app is running (that are not in a block yet)
- Do show notifications on new transactions received since the app was last used.