### PR TITLE
Resolve issue of 100x dash -> fiat values

### DIFF
--- a/wallet/src/de/schildbach/wallet/Constants.java
+++ b/wallet/src/de/schildbach/wallet/Constants.java
@@ -212,6 +212,8 @@ public final class Constants {
 
     public static final MonetaryFormat LOCAL_FORMAT = new MonetaryFormat()
             .noCode().withLocale(Locale.getDefault()).minDecimals(2).optionalDecimals().withGroupingSeparator();
+    public static final MonetaryFormat LOCAL_FORMAT_NO_SEP = new MonetaryFormat()
+            .noCode().minDecimals(2).optionalDecimals();
 
     public static final BaseEncoding HEX = BaseEncoding.base16().lowerCase();
 

--- a/wallet/src/de/schildbach/wallet/ui/RequestCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/RequestCoinsFragment.java
@@ -161,8 +161,8 @@ public final class RequestCoinsFragment extends Fragment implements NfcAdapter.C
 
         final CurrencyAmountView localAmountView = (CurrencyAmountView) view
                 .findViewById(R.id.request_coins_amount_local);
-        localAmountView.setInputFormat(Constants.LOCAL_FORMAT);
-        localAmountView.setHintFormat(Constants.LOCAL_FORMAT);
+        localAmountView.setInputFormat(Constants.LOCAL_FORMAT_NO_SEP);
+        localAmountView.setHintFormat(Constants.LOCAL_FORMAT_NO_SEP);
         amountCalculatorLink = new CurrencyCalculatorLink(btcAmountView, localAmountView);
 
         acceptBluetoothPaymentView = (CheckBox) view.findViewById(R.id.request_coins_accept_bluetooth_payment);

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
@@ -625,8 +625,8 @@ public final class SendCoinsFragment extends Fragment {
         btcAmountView.setHintFormat(config.getFormat());
 
         final CurrencyAmountView localAmountView = (CurrencyAmountView) view.findViewById(R.id.send_coins_amount_local);
-        localAmountView.setInputFormat(Constants.LOCAL_FORMAT);
-        localAmountView.setHintFormat(Constants.LOCAL_FORMAT);
+        localAmountView.setInputFormat(Constants.LOCAL_FORMAT_NO_SEP);
+        localAmountView.setHintFormat(Constants.LOCAL_FORMAT_NO_SEP);
         amountCalculatorLink = new CurrencyCalculatorLink(btcAmountView, localAmountView);
         amountCalculatorLink.setExchangeDirection(config.getLastExchangeDirection());
 


### PR DESCRIPTION
This resolves the issue of ever increasing fiat values, when tapping on dash and fiat fields on the send or request screens in locales that switch , and . compared to US.