### PR TITLE
C++:  Add parameters to x11 native hash function

### DIFF
--- a/wallet/cpp/hashblock.cpp
+++ b/wallet/cpp/hashblock.cpp
@@ -6,16 +6,15 @@
 
 #include <jni.h>
 
-jbyteArray JNICALL x11_native(JNIEnv *env, jclass cls, jbyteArray input)
+jbyteArray JNICALL x11_native(JNIEnv *env, jclass cls, jbyteArray input, jint offset, jint length)
 {
-    jint Plen = (env)->GetArrayLength(input);
     jbyte *pInput = (env)->GetByteArrayElements(input, NULL);
     jbyteArray byteArray = NULL;
 
     if (pInput)
-	{
-	    jbyte result[HASH256_SIZE];
-	    HashX11((uint8_t *)pInput, (uint8_t *)pInput+Plen, (uint8_t *)result);
+    {
+        jbyte result[HASH256_SIZE];
+        HashX11((uint8_t *)pInput+offset, (uint8_t *)pInput+offset+length, (uint8_t *)result);
 
         byteArray = (env)->NewByteArray(32);
         if (byteArray)
@@ -24,7 +23,7 @@ jbyteArray JNICALL x11_native(JNIEnv *env, jclass cls, jbyteArray input)
         }
 
         (env)->ReleaseByteArrayElements(input, pInput, JNI_ABORT);
-	} else {
+    } else {
         jclass e = env->FindClass("java/lang/NullPointerException");
         env->ThrowNew(e, "input is null");
     }
@@ -32,7 +31,7 @@ jbyteArray JNICALL x11_native(JNIEnv *env, jclass cls, jbyteArray input)
 }
 
 static const JNINativeMethod methods[] = {
-    { "x11_native", "([B)[B", (void *) x11_native }
+        { "x11_native", "([BII)[B", (void *) x11_native }
 };
 
 jint JNI_OnLoad(JavaVM *vm, void *reserved) {


### PR DESCRIPTION
In previous version of DashJ, this code was called everytime a block was processed from the blockchain.

```
public static byte[] x11Digest(byte[] input, int offset, int length)
    {
        byte [] buf = new byte[length];
        for(int i = 0; i < length; ++i)
        {
            buf[i] = input[offset + i];
        }
        return x11Digest(buf);
}
```

This method was copying the block header into a new byte [] array.  Consider that in one second, the app may process up to 300 blocks.  This allocates 24KB of memory per second (until garbage collection occurs).  This is passed to the native or java x11 hash function and then gets de-referenced.

Now in a new PR on DashJ (https://github.com/dashevo/dashj/pull/59)

```
    public static byte[] x11Digest(byte[] input, int offset, int length)
    {
        try {
            return native_library_loaded ? x11_native(input, offset, length) : x11(input, offset, length);
        } catch (Exception e) {
            return null;
        }
    }
```
With this change, the x11_native function must accept an offset and length:
`jbyteArray JNICALL x11_native(JNIEnv *env, jclass cls, jbyteArray input, jint offset, jint length)` 