### PR TITLE
Remove Sync Restart button

### DIFF
--- a/wallet/res/layout/sync_status_pane.xml
+++ b/wallet/res/layout/sync_status_pane.xml
@@ -72,7 +72,7 @@
         android:visibility="gone">
 
         <LinearLayout
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_centerVertical="true"
             android:layout_marginStart="16dp"
@@ -95,16 +95,6 @@
                 android:textColor="@color/dash_white" />
 
         </LinearLayout>
-
-        <ImageView
-            android:id="@+id/restart_sync_icon"
-            android:layout_width="@dimen/app_bar_logo_width"
-            android:layout_height="@dimen/app_bar_logo_height"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="false"
-            android:layout_centerInParent="true"
-            android:foregroundGravity="right"
-            android:src="@drawable/reload_icon_white" />
 
     </RelativeLayout>
 

--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -1061,12 +1061,6 @@ public final class WalletActivity extends AbstractBindServiceActivity
     @Override
     public void onStart() {
         super.onStart();
-        findViewById(R.id.restart_sync_icon).setOnClickListener(new View.OnClickListener() {
-            public void onClick(final View v) {
-                findViewById(R.id.sync_error_pane).setVisibility(View.GONE);
-                findViewById(R.id.sync_progress_pane).setVisibility(View.VISIBLE);
-            }
-        });
         EventBus.getDefault().register(this);
     }
 


### PR DESCRIPTION
The restart button that appears in the red rectangle with the message "Unable to connect" and "Check your connection" does not cause the app to try to reconnect to the Dash Network.  The app does that on its own, therefore the button will be removed. [See NMA-29]

