### PR TITLE
Redesign:  Add Friendly Recovery Phrase Error Messages (NMA-284)

### DIFF
--- a/wallet/res/layout/activity_recover_wallet_from_seed.xml
+++ b/wallet/res/layout/activity_recover_wallet_from_seed.xml
@@ -42,7 +42,6 @@
             style="@style/DashButton.Blue"
             android:id="@+id/submit"
             android:enabled="false"
-            android:onClick="onContinueClick"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="10dp"

--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -101,7 +101,9 @@
     <string name="button_copy_address">Copy address</string>
     <string name="request_coins_clipboard_address_msg">Dash address copied to clipboard</string>
     <string name="backup_wallet_to_seed_show_recovery_phrase">Show</string>
-    <string name="restore_wallet_from_invalid_seed_warning_message">%s is an invalid word.</string>
+    <string name="restore_wallet_from_invalid_seed_warning_message">\"%s\" is not a recovery phrase word</string>
+    <string name="restore_wallet_from_invalid_seed_not_twelve_words">Recovery phrase must have 12 words</string>
+    <string name="restore_wallet_from_invalid_seed_bad_checksum">Bad recovery phrase</string>
 
     <string name="send_coins_options_fee_category_zero">No Fee</string>
     <string name="send_coins_fragment_hint_fee_zero">No fee of will be paid. Use \'no fee\' only if you don\'t care about confirmation time.</string>

--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -104,6 +104,7 @@
     <string name="restore_wallet_from_invalid_seed_warning_message">\"%s\" is not a recovery phrase word</string>
     <string name="restore_wallet_from_invalid_seed_not_twelve_words">Recovery phrase must have 12 words</string>
     <string name="restore_wallet_from_invalid_seed_bad_checksum">Bad recovery phrase</string>
+    <string name="restore_wallet_from_invalid_seed_failure">Wallet could not be restored:\n\n%s\n\nBad recovery phrase?</string>
 
     <string name="send_coins_options_fee_category_zero">No Fee</string>
     <string name="send_coins_fragment_hint_fee_zero">No fee of will be paid. Use \'no fee\' only if you don\'t care about confirmation time.</string>

--- a/wallet/src/de/schildbach/wallet/ui/OnboardingActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/OnboardingActivity.kt
@@ -144,10 +144,6 @@ class OnboardingActivity : RestoreFromFileActivity() {
         sloganDrawable.mutate().alpha = 0
     }
 
-    fun restoreWalletFromSeed(words: MutableList<String>) {
-        viewModel.restoreWalletFromSeed(words)
-    }
-
     private fun getStatusBarHeightPx(): Int {
         var result = 0
         val resourceId = resources.getIdentifier("status_bar_height", "dimen", "android")

--- a/wallet/src/de/schildbach/wallet/ui/OnboardingActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/OnboardingActivity.kt
@@ -102,7 +102,6 @@ class OnboardingActivity : RestoreFromFileActivity() {
         recovery_wallet.setOnClickListener {
             walletApplication.initEnvironmentIfNeeded()
             startActivity(Intent(this, RestoreWalletFromSeedActivity::class.java))
-//            RestoreWalletFromSeedDialogFragment.show(supportFragmentManager)
         }
         restore_wallet.setOnClickListener {
             restoreWalletFromFile()

--- a/wallet/src/de/schildbach/wallet/ui/RestoreWalletFromSeedActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/RestoreWalletFromSeedActivity.kt
@@ -17,12 +17,16 @@
 package de.schildbach.wallet.ui
 
 import android.annotation.SuppressLint
-import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
+import android.text.TextUtils
 import android.text.TextWatcher
 import android.view.View
+import android.widget.Toast
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProviders
 import de.schildbach.wallet.Constants
+import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet.util.WalletUtils
 import de.schildbach.wallet_test.R
 import kotlinx.android.synthetic.main.activity_recover_wallet_from_seed.*
@@ -33,18 +37,29 @@ import org.slf4j.LoggerFactory
 import java.util.*
 
 
-class RestoreWalletFromSeedActivity : BaseMenuActivity() {
+class RestoreWalletFromSeedActivity : RestoreFromFileActivity() {
     private val log = LoggerFactory.getLogger(RestoreWalletFromSeedDialogFragment::class.java)
 
+    private lateinit var viewModel: RestoreWalletFromSeedViewModel
 
-    override fun getLayoutId(): Int {
-        return R.layout.activity_recover_wallet_from_seed
-    }
+    private lateinit var walletApplication: WalletApplication
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        setContentView(R.layout.activity_recover_wallet_from_seed)
+
         setTitle(R.string.recover_wallet_title)
+
+        walletApplication = (application as WalletApplication)
+
+        viewModel = ViewModelProviders.of(this).get(RestoreWalletFromSeedViewModel::class.java)
+
+        initView()
+        initViewModel()
+    }
+
+    private fun initView() {
         input.requestFocus()
         input.addTextChangedListener(object : TextWatcher {
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
@@ -53,60 +68,37 @@ class RestoreWalletFromSeedActivity : BaseMenuActivity() {
             override fun afterTextChanged(s: Editable?) { }
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { }
         })
-
+        submit.setOnClickListener {
+            walletApplication.initEnvironmentIfNeeded()
+            val seed = input.text.trim()
+            if (seed.isNotEmpty()) {
+                val words = ArrayList(mutableListOf(*seed.split(' ').toTypedArray()))
+                viewModel.restoreWalletFromSeed(words)
+            }
+        }
     }
 
     @SuppressLint("StringFormatInvalid")
-    fun onContinueClick(view: View) {
-        val seed = input.text.trim()
-        if (seed.isEmpty()) {
-            return
-        }
-
-        val words = ArrayList(mutableListOf(*seed.split(' ').toTypedArray()))
-
-        try {
-            if(words.size != 12)
-                throw MnemonicException.MnemonicLengthException("There are not 12 words")
-            MnemonicCode.INSTANCE.check(words)
-        } catch (x: MnemonicException) {
-            log.info("problem restoring wallet from seed: ", x)
+    private fun initViewModel() {
+        viewModel.showRestoreWalletFailureAction.observe(this, Observer {
+            val message = when {
+                TextUtils.isEmpty(it.message) -> it.javaClass.simpleName
+                else -> it.message!!
+            }
             val dialog = DialogBuilder.warn(this, R.string.import_export_keys_dialog_failure_title)
-            var errorMessage = getString(R.string.import_keys_dialog_failure, x.message)
-            if(x is MnemonicException.MnemonicLengthException)
-                errorMessage = getString(R.string.restore_wallet_from_invalid_seed_not_twelve_words)
-            else if(x is MnemonicException.MnemonicChecksumException)
-                errorMessage = getString(R.string.restore_wallet_from_invalid_seed_bad_checksum)
-            else if(x is MnemonicException.MnemonicWordException) {
-                var firstInvalidWord = "unknown"
-                for(word in words) {
-                    if(MnemonicCode.INSTANCE.wordList.lastIndexOf(word) == -1) {
-                        firstInvalidWord = word
-                        break
-                    }
-                }
-                errorMessage = getString(R.string.restore_wallet_from_invalid_seed_warning_message, firstInvalidWord)
+
+            val errorMessage = when (it) {
+                is MnemonicException.MnemonicLengthException -> walletApplication.getString(R.string.restore_wallet_from_invalid_seed_not_twelve_words)
+                is MnemonicException.MnemonicChecksumException -> walletApplication.getString(R.string.restore_wallet_from_invalid_seed_bad_checksum)
+                is MnemonicException.MnemonicWordException -> walletApplication.getString(R.string.restore_wallet_from_invalid_seed_warning_message, it.badWord)
+                else -> walletApplication.getString(R.string.restore_wallet_from_invalid_seed_failure, message)
             }
             dialog.setMessage(errorMessage)
             dialog.setPositiveButton(R.string.button_dismiss, null)
             dialog.show()
-            return
-        }
-
-        walletApplication.wallet = WalletUtils
-                .restoreWalletFromSeed(words, Constants.NETWORK_PARAMETERS)
-        log.info("successfully restored wallet from seed")
-        walletApplication.configuration.disarmBackupSeedReminder()
-        walletApplication.configuration.isRestoringBackup = true
-
-        val dialog = DialogBuilder(this)
-        dialog.setTitle(R.string.restore_wallet_dialog_success)
-        dialog.setMessage(getString(R.string.restore_wallet_dialog_success_replay))
-        dialog.setPositiveButton(R.string.button_ok) { _, _ ->
-            val intent = SetPinActivity
-                    .createIntent(walletApplication, R.string.set_pin_create_new_wallet)
-            startActivity(intent)
-        }
-        dialog.show()
+        })
+        viewModel.startActivityAction.observe(this, Observer {
+            startActivity(it)
+        })
     }
 }

--- a/wallet/src/de/schildbach/wallet/ui/RestoreWalletFromSeedDialogFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/RestoreWalletFromSeedDialogFragment.java
@@ -58,6 +58,8 @@ import de.schildbach.wallet.util.Crypto;
 import de.schildbach.wallet.util.KeyboardUtil;
 import de.schildbach.wallet.util.WalletUtils;
 import de.schildbach.wallet_test.R;
+import android.annotation.SuppressLint;
+
 
 public class RestoreWalletFromSeedDialogFragment extends DialogFragment {
 
@@ -191,7 +193,6 @@ public class RestoreWalletFromSeedDialogFragment extends DialogFragment {
         try {
             MnemonicCode.INSTANCE.check(words);
             activity.restoreWallet(WalletUtils.restoreWalletFromSeed(words, Constants.NETWORK_PARAMETERS));
-            Intent intent = new Intent()
 
             log.info("successfully restored wallet from seed: {}", words.size());
         } catch (final IOException | MnemonicException x) {

--- a/wallet/src/de/schildbach/wallet/ui/RestoreWalletFromSeedDialogFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/RestoreWalletFromSeedDialogFragment.java
@@ -120,7 +120,6 @@ public class RestoreWalletFromSeedDialogFragment extends DialogFragment {
         final TextView messageView = (TextView) view.findViewById(R.id.restore_wallet_dialog_message);
         messageView.setText(getString(R.string.import_keys_from_seed_dialog_message));
         replaceWarningView = view.findViewById(R.id.restore_wallet_from_storage_dialog_replace_warning);
-        //final Spinner fileView = (Spinner) view.findViewById(R.id.import_keys_from_storage_file);
         passwordView = (EditText) view.findViewById(R.id.import_seed_recovery_phrase);
         setupPasswordView();
         invalidWordView = (TextView)view.findViewById(R.id.restore_wallet_from_invalid_seed_warning);
@@ -128,23 +127,12 @@ public class RestoreWalletFromSeedDialogFragment extends DialogFragment {
         builder.setPositiveButton(R.string.import_keys_dialog_button_import, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(final DialogInterface dialog, final int which) {
-                //final File file = (File) fileView.getSelectedItem();
                 final String password = passwordView.getText().toString().trim();
                 clearPasswordView();
 
                 List<String> words = new ArrayList<>(Arrays.asList(password.split(" ")));
 
-                //if (WalletUtils.BACKUP_FILE_FILTER.accept(file))
-                //    restoreWalletFromProtobuf(file);
-                //else if (WalletUtils.KEYS_FILE_FILTER.accept(file))
-                //    restorePrivateKeysFromBase58(file);
-                //else if (Crypto.OPENSSL_FILE_FILTER.accept(file))
-                //    restoreWalletFromEncrypted(file, password);
-                if (activity instanceof OnboardingActivity) {
-                    ((OnboardingActivity) activity).restoreWalletFromSeed(words);
-                } else {
-                    restoreWalletFromSeed(words);
-                }
+                restoreWalletFromSeed(words);
             }
         });
         builder.setNegativeButton(R.string.button_cancel, new DialogInterface.OnClickListener() {
@@ -154,16 +142,6 @@ public class RestoreWalletFromSeedDialogFragment extends DialogFragment {
             }
         });
 
-        /*final String path;
-        final String backupPath = Constants.Files.EXTERNAL_WALLET_BACKUP_DIR.getAbsolutePath();
-        final String storagePath = Constants.Files.EXTERNAL_STORAGE_DIR.getAbsolutePath();
-        if (backupPath.startsWith(storagePath))
-            path = backupPath.substring(storagePath.length());
-        else
-            path = backupPath;
-            */
-
-        //fileView.setAdapter(adapter);
         return builder.create();
     }
 
@@ -207,11 +185,13 @@ public class RestoreWalletFromSeedDialogFragment extends DialogFragment {
         });
     }
 
+    @SuppressLint("StringFormatInvalid")
     private void restoreWalletFromSeed(final List<String> words) {
         final WalletActivity activity = (WalletActivity) this.activity;
         try {
             MnemonicCode.INSTANCE.check(words);
             activity.restoreWallet(WalletUtils.restoreWalletFromSeed(words, Constants.NETWORK_PARAMETERS));
+            Intent intent = new Intent()
 
             log.info("successfully restored wallet from seed: {}", words.size());
         } catch (final IOException | MnemonicException x) {
@@ -257,10 +237,6 @@ public class RestoreWalletFromSeedDialogFragment extends DialogFragment {
 
         clearPasswordView();
         setupRestoreButtonState();
-        //fileView.setOnItemSelectedListener(dialogButtonEnabler);
-
-        //final CheckBox showView = (CheckBox) alertDialog.findViewById(R.id.import_keys_from_storage_show);
-        //showView.setOnCheckedChangeListener(new ShowPasswordCheckListener(passwordView));
     }
 
     private void setupRestoreButtonState() {

--- a/wallet/src/de/schildbach/wallet/ui/RestoreWalletFromSeedViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/RestoreWalletFromSeedViewModel.kt
@@ -25,25 +25,30 @@ import de.schildbach.wallet.util.WalletUtils
 import de.schildbach.wallet_test.R
 import org.bitcoinj.crypto.MnemonicCode
 import org.bitcoinj.crypto.MnemonicException
-import org.bitcoinj.wallet.Wallet
 import org.slf4j.LoggerFactory
 
-class OnboardingViewModel(application: Application) : AndroidViewModel(application) {
+class RestoreWalletFromSeedViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val log = LoggerFactory.getLogger(OnboardingViewModel::class.java)
+    private val log = LoggerFactory.getLogger(RestoreWalletFromSeedViewModel::class.java)
 
     private val walletApplication = application as WalletApplication
 
-    internal val showToastAction = SingleLiveEvent<String>()
     internal val showRestoreWalletFailureAction = SingleLiveEvent<MnemonicException>()
     internal val startActivityAction = SingleLiveEvent<Intent>()
 
-    fun createNewWallet() {
-        walletApplication.initEnvironmentIfNeeded()
-        val wallet = Wallet(Constants.NETWORK_PARAMETERS)
-        log.info("successfully created new wallet")
+    fun restoreWalletFromSeed(words: MutableList<String>) {
+        try {
+            MnemonicCode.INSTANCE.check(words)
+        } catch (x: MnemonicException) {
+            log.info("problem restoring wallet from seed: ", x)
+            showRestoreWalletFailureAction.call(x)
+            return
+        }
+        val wallet = WalletUtils.restoreWalletFromSeed(words, Constants.NETWORK_PARAMETERS)
         walletApplication.wallet = wallet
-        walletApplication.configuration.armBackupSeedReminder()
-        startActivityAction.call(SetPinActivity.createIntent(getApplication(), R.string.set_pin_create_new_wallet))
+        log.info("successfully restored wallet from seed")
+        walletApplication.configuration.disarmBackupSeedReminder()
+        walletApplication.configuration.isRestoringBackup = true
+        startActivityAction.call(SetPinActivity.createIntent(getApplication(), R.string.set_pin_restore_wallet))
     }
 }


### PR DESCRIPTION
Instead of having an error message that includes words like "MnemonicException" and "Bad password" when a user enters a recovery phrase that has errors, this PR will use the same error messages as the iOS app, which include "Bad recovery phrase", "%s is not a valid recovery phrase word" and "Recovery phrase must be 12 words"

Additional changes include converting the RestoreWalletFromSeedActivity class to be more similar to the OnboardingActivity, which includes similar view model.  Some methods were removed from the OnboardingViewModel and placed in the RestoreWalletFromSeedViewModel.