### PR TITLE
NMA-27: Redesign: rescan does nothing

### DIFF
--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -705,9 +705,14 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
         if (!blockChainFileExists) {
             log.info("blockchain does not exist, resetting wallet");
             wallet.reset();
-            SimplifiedMasternodeListManager manager = wallet.getContext().masternodeListManager;
-            if(manager != null)
-                manager.resetMNList(true, true);
+            try {
+                SimplifiedMasternodeListManager manager = wallet.getContext().masternodeListManager;
+                if (manager != null)
+                    manager.resetMNList(true, true);
+            } catch (RuntimeException x) {
+                // swallow this exception.  It is thrown when there is not a bootstrap mnlist file
+                // there is not a bootstrap mnlist file for testnet
+            }
         }
 
         try {

--- a/wallet/src/de/schildbach/wallet/ui/MoreActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/MoreActivity.kt
@@ -27,6 +27,12 @@ import org.dash.wallet.integration.uphold.ui.UpholdAccountActivity
 
 class MoreActivity : GlobalFooterActivity() {
 
+    companion object {
+        const val REQUEST_CODE_FINISH = 1
+
+        const val RESULT_CODE_FINISH_YES = 1
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentViewWithFooter(R.layout.activity_more)
@@ -47,10 +53,10 @@ class MoreActivity : GlobalFooterActivity() {
             startActivity(Intent(this, SecurityActivity::class.java))
         }
         settings.setOnClickListener {
-            startActivity(Intent(this, SettingsActivity::class.java))
+            startActivityForResult(Intent(this, SettingsActivity::class.java), REQUEST_CODE_FINISH)
         }
         tools.setOnClickListener {
-            startActivity(Intent(this, ToolsActivity::class.java))
+            startActivityForResult(Intent(this, ToolsActivity::class.java), REQUEST_CODE_FINISH)
         }
     }
 
@@ -74,4 +80,11 @@ class MoreActivity : GlobalFooterActivity() {
         return super.onOptionsItemSelected(item)
     }
 
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if(requestCode == REQUEST_CODE_FINISH && resultCode == RESULT_CODE_FINISH_YES) {
+            finish()
+            return
+        }
+        super.onActivityResult(requestCode, resultCode, data)
+    }
 }

--- a/wallet/src/de/schildbach/wallet/ui/SettingsActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SettingsActivity.kt
@@ -18,10 +18,8 @@ package de.schildbach.wallet.ui
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.appcompat.widget.Toolbar
 import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet_test.R
-import kotlinx.android.synthetic.main.activity_more.*
 import kotlinx.android.synthetic.main.activity_settings.*
 import org.dash.wallet.common.ui.DialogBuilder
 import org.slf4j.LoggerFactory
@@ -29,6 +27,10 @@ import org.slf4j.LoggerFactory
 class SettingsActivity : BaseMenuActivity() {
 
     private val log = LoggerFactory.getLogger(SettingsActivity::class.java)
+
+    companion object {
+        const val CODE_RESET_BLOCKCHAIN = 1
+    }
 
     override fun getLayoutId(): Int {
         return R.layout.activity_settings
@@ -61,10 +63,10 @@ class SettingsActivity : BaseMenuActivity() {
             log.info("manually initiated blockchain reset")
 
             WalletApplication.getInstance().resetBlockchain()
+            setResult(MoreActivity.RESULT_CODE_FINISH_YES)
             finish()
         }
         dialog.setNegativeButton(R.string.button_dismiss, null)
         dialog.show()
     }
-
 }

--- a/wallet/src/de/schildbach/wallet/ui/SettingsActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SettingsActivity.kt
@@ -28,10 +28,6 @@ class SettingsActivity : BaseMenuActivity() {
 
     private val log = LoggerFactory.getLogger(SettingsActivity::class.java)
 
-    companion object {
-        const val CODE_RESET_BLOCKCHAIN = 1
-    }
-
     override fun getLayoutId(): Int {
         return R.layout.activity_settings
     }

--- a/wallet/src/de/schildbach/wallet/ui/ToolsActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/ToolsActivity.kt
@@ -43,4 +43,13 @@ class ToolsActivity : BaseMenuActivity() {
         }
     }
 
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if(requestCode == MoreActivity.REQUEST_CODE_FINISH && resultCode == MoreActivity.RESULT_CODE_FINISH_YES) {
+            setResult(MoreActivity.RESULT_CODE_FINISH_YES)
+            finish()
+            return
+        }
+        super.onActivityResult(requestCode, resultCode, data)
+    }
+
 }

--- a/wallet/src/de/schildbach/wallet/ui/send/SweepWalletFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SweepWalletFragment.java
@@ -83,6 +83,7 @@ import de.schildbach.wallet.rates.ExchangeRate;
 import de.schildbach.wallet.rates.ExchangeRatesViewModel;
 import de.schildbach.wallet.ui.AbstractBindServiceActivity;
 import de.schildbach.wallet.ui.InputParser.StringInputParser;
+import de.schildbach.wallet.ui.MoreActivity;
 import de.schildbach.wallet.ui.ProgressDialogFragment;
 import de.schildbach.wallet.ui.TransactionResultActivity;
 import de.schildbach.wallet.ui.scan.ScanActivity;
@@ -625,6 +626,7 @@ public class SweepWalletFragment extends Fragment {
 		Intent transactionResultIntent = TransactionResultActivity.createIntent(activity, sentTransaction,
 				receivingAddress);
 		startActivity(transactionResultIntent);
+		activity.setResult(MoreActivity.RESULT_CODE_FINISH_YES);
 		activity.finish();
 	}
 


### PR DESCRIPTION
NMA-27 nothing happens when click Rescan wallet

The rescan function appears to do nothing since the screen remained on the Settings screen instead of returning to the home screen.

This PR will address that by returning the app to the Home Screen.  Question:  Is there a better way to do this?

Additionally, the same thing will happen for the Import Private Key function on the tools screen.

Lastly, this will fix a crash on testnet when the blockchain is reset.