### PR TITLE
Spending Confirmation

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
@@ -225,7 +225,7 @@ public final class SendCoinsFragment extends Fragment {
             @Override
             public void onChanged(Boolean aBoolean) {
                 String sessionPin = activity.getSessionPin();
-                if (sessionPin == null) {
+                if (sessionPin == null || config.getSpendingConfirmationEnabled()) {
                     CheckPinDialog.show(activity, AUTH_REQUEST_CODE_SEND);
                 } else {
                     handleGo(sessionPin);


### PR DESCRIPTION
ON = The user will always have to authenticate before sending a payment

OFF = The user will not have to authenticate to send a payment if they already authenticated it on the lock screen 

If entering the pay flow without authenticating, the user must authenticate before sending the payment (even if Spending Confirmation = OFF)

The default setting = ON