### PR TITLE
Redesign: Set Default Currency [NMA-243]

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/data/CurrencyInfo.java
+++ b/common/src/main/java/org/dash/wallet/common/data/CurrencyInfo.java
@@ -60,7 +60,8 @@ public class CurrencyInfo {
 
     static {
         obsoleteCurrencyMap = new HashMap<>();
-        obsoleteCurrencyMap.put("BYR", "BYN");
+        obsoleteCurrencyMap.put("BYR", "BYN"); // Belarus Ruble, changed in 2016
+        obsoleteCurrencyMap.put("MRO", "MRU"); // Mauritania Ouguiya, changed in 2018
 
         otherCurrencyMap = new HashMap<>();
         otherCurrencyMap.put("VES", "Venezuelan Bolívar");
@@ -68,7 +69,11 @@ public class CurrencyInfo {
         otherCurrencyMap.put("JEP", "Jersey Pound");
         otherCurrencyMap.put("IMP", "Isle of Man Pound");
         otherCurrencyMap.put("USDC", "USD Coin");
-
+        otherCurrencyMap.put("LTC", "Litecoin");
+        otherCurrencyMap.put("ETH", "Etherium");
+        otherCurrencyMap.put("BTC", "Bitcoin");
+        otherCurrencyMap.put("PAX", "Paxos Standard");
+        otherCurrencyMap.put("GUSD", "Gemini Dollar");
 
         useOtherNameMap = new HashMap<>();
         useOtherNameMap.put("CNH", "CNY");

--- a/common/src/main/java/org/dash/wallet/common/data/CurrencyInfo.java
+++ b/common/src/main/java/org/dash/wallet/common/data/CurrencyInfo.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 Dash Core Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dash.wallet.common.data;
+
+import android.annotation.TargetApi;
+import android.os.Build;
+
+import java.util.Currency;
+import java.util.HashMap;
+
+/**
+    @author: Eric Britten
+ */
+
+public class CurrencyInfo {
+
+    /*
+        Older android devices will have obsolete currency codes
+        that do not match what the prices sources currently used.
+
+        e.g. in Belarus (BY), the currency changed from BYR to BYN
+        at the end of 2016.  Older phones have BYR.
+
+        This app will read BYR from the device and then query BYN
+        in the exchange rates list, but must get the name of BYR
+        from the device.
+     */
+    private static HashMap<String, String> obsoleteCurrencyMap;
+
+    /*
+        These currencies are listed in the price data, but are not
+        ISO 4217 currency codes.  This will map those codes to the
+        currency names.
+     */
+    private static HashMap<String, String> otherCurrencyMap;
+
+    /*
+        These currencies are listed in the price data and have the
+        same name as a different currency.  This differs from
+        obsoleteCurrencyMap because both of these codes exist in the
+        price sources.
+
+        e.g CNH vs CNY (ISO 4217)
+     */
+    private static HashMap<String, String> useOtherNameMap;
+
+
+    static {
+        obsoleteCurrencyMap = new HashMap<>();
+        obsoleteCurrencyMap.put("BYR", "BYN");
+
+        otherCurrencyMap = new HashMap<>();
+        otherCurrencyMap.put("VES", "Venezuelan Bolívar");
+        otherCurrencyMap.put("GGP", "Guernsey Pound");
+        otherCurrencyMap.put("JEP", "Jersey Pound");
+        otherCurrencyMap.put("IMP", "Isle of Man Pound");
+
+        useOtherNameMap = new HashMap<>();
+        useOtherNameMap.put("CNH", "CNY");
+    }
+
+    public static boolean hasObsoleteCurrency(String code) {
+        return obsoleteCurrencyMap.containsKey(code);
+    }
+
+    public static String getUpdatedCurrency(String code) {
+        return obsoleteCurrencyMap.get(code);
+    }
+
+    // convert an updated code to an obsolete code
+    public static String getObsoleteCurrency(String updatedCode) {
+        for (String obsoleteCode : obsoleteCurrencyMap.keySet()) {
+            if(obsoleteCurrencyMap.get(obsoleteCode).equals(updatedCode)) {
+                return obsoleteCode;
+            }
+        }
+        return null;
+    }
+
+    // obtain a currency name for those codes for which the local has no information
+    public static String getOtherCurrencyName(String currencyCode) {
+        String currencyName = "";
+        currencyCode = currencyCode.toUpperCase();
+
+        String oldCurrencyCode = CurrencyInfo.getObsoleteCurrency(currencyCode);
+        if(oldCurrencyCode != null) {
+            currencyName = getCurrencyNameFromCode(oldCurrencyCode);
+        } else {
+            // handle cases where the phone doesn't have currency information
+
+            // for CNH, use the name for CNY
+            if(useOtherNameMap.containsKey(currencyCode)) {
+                String useNameOfCode = useOtherNameMap.get(currencyCode);
+                currencyName = getCurrencyNameFromCode(useNameOfCode);
+            } else if(otherCurrencyMap.containsKey(currencyCode)) {
+                currencyName = otherCurrencyMap.get(currencyCode);
+            }
+        }
+
+        return currencyName;
+    }
+
+    @TargetApi(Build.VERSION_CODES.KITKAT)
+    public static String getCurrencyNameFromCode(String code) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            Currency oldCurrency = Currency.getInstance(code.toUpperCase());
+            return oldCurrency.getDisplayName();
+        } else {
+            return "";
+        }
+    }
+}

--- a/common/src/main/java/org/dash/wallet/common/data/CurrencyInfo.java
+++ b/common/src/main/java/org/dash/wallet/common/data/CurrencyInfo.java
@@ -67,6 +67,8 @@ public class CurrencyInfo {
         otherCurrencyMap.put("GGP", "Guernsey Pound");
         otherCurrencyMap.put("JEP", "Jersey Pound");
         otherCurrencyMap.put("IMP", "Isle of Man Pound");
+        otherCurrencyMap.put("USDC", "USD Coin");
+
 
         useOtherNameMap = new HashMap<>();
         useOtherNameMap.put("CNH", "CNY");

--- a/wallet/src/de/schildbach/wallet/rates/ExchangeRate.java
+++ b/wallet/src/de/schildbach/wallet/rates/ExchangeRate.java
@@ -8,6 +8,7 @@ import androidx.room.Ignore;
 import androidx.room.PrimaryKey;
 
 import org.bitcoinj.utils.Fiat;
+import org.dash.wallet.common.data.CurrencyInfo;
 
 import java.math.BigDecimal;
 import java.util.Currency;
@@ -72,11 +73,16 @@ public class ExchangeRate {
         if (currencyName == null) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
                 currencyName = getCurrency().getDisplayName();
+                if(currencyCode.toUpperCase().equals(currencyName.toUpperCase())) {
+                    currencyName = CurrencyInfo.getOtherCurrencyName(currencyCode);
+                }
             } else {
+                // before kitkat, no names will be displayed
+                // this doesn't matter since the app doesn't run on
+                // pre kitkat devices
                 currencyName = "";
             }
         }
         return currencyName;
     }
-
 }

--- a/wallet/src/de/schildbach/wallet/rates/ExchangeRate.java
+++ b/wallet/src/de/schildbach/wallet/rates/ExchangeRate.java
@@ -72,7 +72,11 @@ public class ExchangeRate {
 
         if (currencyName == null) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                currencyName = getCurrency().getDisplayName();
+                // currency codes must be 3 letters before calling getCurrency()
+                if(currencyCode.length() == 3)
+                    currencyName = getCurrency().getDisplayName();
+                else currencyName = currencyCode;
+
                 if(currencyCode.toUpperCase().equals(currencyName.toUpperCase())) {
                     currencyName = CurrencyInfo.getOtherCurrencyName(currencyCode);
                 }

--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -1110,8 +1110,6 @@ public final class WalletActivity extends AbstractBindServiceActivity
         }
     }
 
-
-
     private void setDefaultCurrency() {
         String countryCode = getCurrentCountry();
         log.info("Setting default currency:");

--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -1098,6 +1098,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
             }
         } catch (Exception e) {
             //fail safe
+            log.info("NMA-243:  Exception thrown obtaining Locale information: ", e);
         }
     }
 

--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -37,6 +37,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
+import android.os.LocaleList;
 import android.telephony.TelephonyManager;
 import android.view.ContextMenu;
 import android.view.Menu;
@@ -69,6 +70,7 @@ import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.crypto.ChildNumber;
 import org.bitcoinj.wallet.Wallet;
 import org.dash.wallet.common.Configuration;
+import org.dash.wallet.common.data.CurrencyInfo;
 import org.dash.wallet.common.ui.DialogBuilder;
 import org.dash.wallet.integration.uphold.data.UpholdClient;
 import org.dash.wallet.integration.uphold.ui.UpholdAccountActivity;
@@ -1080,25 +1082,70 @@ public final class WalletActivity extends AbstractBindServiceActivity
         try {
             final TelephonyManager tm = (TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE);
             final String simCountry = tm.getSimCountryIso();
+
+            log.info("Detecting currency based on device, mobile network or locale:");
             if (simCountry != null && simCountry.length() == 2) { // SIM country code is available
+                log.info("Device Sim Country: " + simCountry);
                 updateCurrencyExchange(simCountry.toUpperCase());
             } else if (tm.getPhoneType() != TelephonyManager.PHONE_TYPE_CDMA) { // device is not 3G (would be unreliable)
                 String networkCountry = tm.getNetworkCountryIso();
+                log.info("Network Country: " + simCountry);
                 if (networkCountry != null && networkCountry.length() == 2) { // network country code is available
                     updateCurrencyExchange(networkCountry.toUpperCase());
                 } else {
                     //Couldn't obtain country code - Use Default
                     if (config.getExchangeCurrencyCode() == null)
-                        config.setExchangeCurrencyCode(Constants.DEFAULT_EXCHANGE_CURRENCY);
+                        setDefaultCurrency();
                 }
             } else {
                 //No cellular network - Wifi Only
                 if (config.getExchangeCurrencyCode() == null)
-                    config.setExchangeCurrencyCode(Constants.DEFAULT_EXCHANGE_CURRENCY);
+                    setDefaultCurrency();
             }
         } catch (Exception e) {
             //fail safe
             log.info("NMA-243:  Exception thrown obtaining Locale information: ", e);
+            if (config.getExchangeCurrencyCode() == null)
+                setDefaultCurrency();
+        }
+    }
+
+
+
+    private void setDefaultCurrency() {
+        String countryCode = getCurrentCountry();
+        log.info("Setting default currency:");
+        if(countryCode != null) {
+            log.info("Local Country: " + countryCode);
+            Locale l = new Locale("", countryCode);
+            Currency currency = Currency.getInstance(l);
+            String newCurrencyCode = currency.getCurrencyCode();
+            if(CurrencyInfo.hasObsoleteCurrency(newCurrencyCode)) {
+                log.info("found obsolete currency: " + newCurrencyCode);
+                newCurrencyCode = CurrencyInfo.getUpdatedCurrency(newCurrencyCode);
+            }
+            log.info("Setting Local Currency: " + newCurrencyCode);
+            config.setExchangeCurrencyCode(newCurrencyCode);
+
+            //Fallback to default
+            if (config.getExchangeCurrencyCode() == null) {
+                log.info("Using default Country: US");
+                log.info("Using default currency: " + Constants.DEFAULT_EXCHANGE_CURRENCY);
+                config.setExchangeCurrencyCode(Constants.DEFAULT_EXCHANGE_CURRENCY);
+            }
+
+        } else {
+            log.info("Using default Country: US");
+            log.info("Using default currency: " + Constants.DEFAULT_EXCHANGE_CURRENCY);
+            config.setExchangeCurrencyCode(Constants.DEFAULT_EXCHANGE_CURRENCY);
+        }
+    }
+
+    private String getCurrentCountry() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N){
+            return LocaleList.getDefault().get(0).getCountry();
+        } else{
+            return Locale.getDefault().getCountry();
         }
     }
 
@@ -1109,6 +1156,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
      * @param countryCode countryCode ISO 3166-1 alpha-2 country code.
      */
     private void updateCurrencyExchange(String countryCode) {
+        log.info("Updating currency exchange rate based on country: " + countryCode);
         Locale l = new Locale("", countryCode);
         Currency currency = Currency.getInstance(l);
         String newCurrencyCode = currency.getCurrencyCode();
@@ -1121,6 +1169,11 @@ public final class WalletActivity extends AbstractBindServiceActivity
             if (config.wasUpgraded()) {
                 showFiatCurrencyChangeDetectedDialog(currentCurrencyCode, newCurrencyCode);
             } else {
+                if(CurrencyInfo.hasObsoleteCurrency(newCurrencyCode)) {
+                    log.info("found obsolete currency: " + newCurrencyCode);
+                    newCurrencyCode = CurrencyInfo.getUpdatedCurrency(newCurrencyCode);
+                }
+                log.info("Setting Local Currency: " + newCurrencyCode);
                 config.setExchangeCurrencyCodeDetected(true);
                 config.setExchangeCurrencyCode(newCurrencyCode);
             }
@@ -1128,6 +1181,8 @@ public final class WalletActivity extends AbstractBindServiceActivity
 
         //Fallback to default
         if (config.getExchangeCurrencyCode() == null) {
+            log.info("Using default Country: US");
+            log.info("Using default currency: " + Constants.DEFAULT_EXCHANGE_CURRENCY);
             config.setExchangeCurrencyCode(Constants.DEFAULT_EXCHANGE_CURRENCY);
         }
     }

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
@@ -61,6 +61,7 @@ import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.protocols.payments.PaymentProtocol;
+import org.bitcoinj.utils.ExchangeRate;
 import org.bitcoinj.utils.Fiat;
 import org.bitcoinj.utils.MonetaryFormat;
 import org.bitcoinj.wallet.KeyChain.KeyPurpose;
@@ -949,11 +950,14 @@ public final class SendCoinsFragment extends Fragment {
         }
 
         String address = viewModel.paymentIntent.getAddress().toBase58();
-        Fiat fiatAmount = enterAmountSharedViewModel.getExchangeRate().coinToFiat(amount);
+        ExchangeRate rate = enterAmountSharedViewModel.getExchangeRate();
+        // prevent crash if the exchange rate is null
+        Fiat fiatAmount = rate != null ? rate.coinToFiat(amount): null;
 
         String amountStr = MonetaryFormat.BTC.noCode().format(amount).toString();
-        String amountFiat = Constants.LOCAL_FORMAT.format(fiatAmount).toString();
-        String fiatSymbol = GenericUtils.currencySymbol(fiatAmount.currencyCode);
+        // if the exchange rate is not available, then show "Not Available"
+        String amountFiat = fiatAmount != null ? Constants.LOCAL_FORMAT.format(fiatAmount).toString() : getString(R.string.transaction_row_rate_not_available);
+        String fiatSymbol = fiatAmount != null ? GenericUtils.currencySymbol(fiatAmount.currencyCode) : "";
         String fee = txFee.toPlainString();
 
         DialogFragment dialog = ConfirmTransactionDialog.createDialog(address, amountStr, amountFiat, fiatSymbol, fee, total);


### PR DESCRIPTION
Several Issues are being address:
1. Special case of BYR (old currency for Belarus-BY that is still in the locale information of older devices before 2017) did not exist in the price sources and this resulted in a crash after sending a transaction.  This crash was a result of the currency not being found in the price source list, which could also happen if the price sources were not available for a new user who just installed the app.  Code was added to treat BYR as BYN to successfully get an exchange rate.
2. Add a list of currency names for non ISO 4217 currencies that are returned by the price sources
3. Add a list of currency codes that should be treated as other codes for the purposes of getting the name.  This applies to non ISO 4218 currency codes that will have the same name as the one that is in ISO 4217.  Example:  CNH vs CNY.
4. Lastly this will set the default currency based on the locale of the device if there is no Sim Card instead of using USD.  The risk with this change is that a locale may specify a currency that is not in the price sources.  In this case the user would have to select a different currency.  This code was added to resolve the first problem above, but it didn't.  This can be removed if we don't want this behavior.
5.  Logging is added to the detectUserCountry() code to help diagnose errors that may occur with users.