### PR TITLE
Redesign: Fix View Recovery Phrase Flow and other security related flows [NMA-299]

### DIFF
--- a/wallet/AndroidManifest.xml
+++ b/wallet/AndroidManifest.xml
@@ -78,6 +78,10 @@
             android:theme="@style/My.Theme.ChildActivity"
             android:screenOrientation="portrait"/>
 
+        <activity android:name="de.schildbach.wallet.ui.ViewSeedActivity"
+            android:theme="@style/My.Theme.ChildActivity"
+            android:screenOrientation="portrait"/>
+
         <activity
             android:name="de.schildbach.wallet.ui.WalletActivity"
             android:configChanges="keyboard|keyboardHidden"

--- a/wallet/res/layout/activity_view_seed.xml
+++ b/wallet/res/layout/activity_view_seed.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/linearLayout2"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/bg_less_bright"
+    android:gravity="center_horizontal">
+
+    <include
+        android:id="@+id/verify_appbar"
+        layout="@layout/app_bar_general"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/recovery_seed"
+        style="@style/VerifySeedTextView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/verify_appbar"
+        tools:text="network   stand   grid   bundle   need   eight   blast   topic   depth   right   desk   faith" />
+
+    <Button
+        android:id="@+id/confirm_btn"
+        style="@style/NewMontserratButton.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_margin="16dp"
+        android:layout_marginBottom="20dp"
+        android:enabled="true"
+        android:maxLines="2"
+        android:text="@string/view_seed_done"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:layout_editor_absoluteX="16dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -201,7 +201,8 @@
     <string name="verify_seed_buttons_tip">Please tap on the words from your recovery phrase in the right order</string>
     <string name="verify_seed_success_title">Verified Successfully</string>
     <string name="verify_seed_success_message">Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.</string>
-
+    <string name="view_seed_done">Done</string>
+    <string name="view_seed_title">Recovery Phrase</string>
 	<string name="transaction_result_view_on_explorer">View on Explorer</string>
 	<string name="transaction_result_paid_successfully">Sent successfully</string>
 	<string name="transaction_result_sent_to">Sent to</string>

--- a/wallet/res/values/strings.xml
+++ b/wallet/res/values/strings.xml
@@ -369,7 +369,7 @@
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
 
-    <string name="activity_security_backup_wallet">Backup Wallet to File</string>
+    <string name="activity_security_backup_wallet">Back Up Wallet to File</string>
     <string name="activity_security_view_recovery_phrase">View Recovery Phrase</string>
     <string name="activity_security_advanced">Advanced Security</string>
     <string name="activity_security_biometric_auth">Fingerprint Authentication</string>

--- a/wallet/src/de/schildbach/wallet/livedata/DecryptSeedLiveData.kt
+++ b/wallet/src/de/schildbach/wallet/livedata/DecryptSeedLiveData.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Dash Core Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.schildbach.wallet.livedata
+
+import android.app.Application
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Process
+import androidx.lifecycle.MutableLiveData
+import de.schildbach.wallet.WalletApplication
+import de.schildbach.wallet.ui.send.DecryptSeedTask
+import de.schildbach.wallet.ui.send.DeriveKeyTask
+import org.bitcoinj.wallet.DeterministicSeed
+import org.bouncycastle.crypto.params.KeyParameter
+
+/**
+ * @author:  Eric Britten
+ */
+
+class DecryptSeedLiveData(application: Application) : MutableLiveData<Resource<Pair<DeterministicSeed?, String?>>>() {
+
+    val backgroundHandler: Handler
+
+    init {
+        val backgroundThread = HandlerThread("backgroundThread", Process.THREAD_PRIORITY_BACKGROUND)
+        backgroundThread.start()
+        backgroundHandler = Handler(backgroundThread.looper)
+    }
+
+    private var decryptSeedTask: DecryptSeedTask? = null
+    private var deriveKeyTask: DeriveKeyTask? = null
+
+    private var walletApplication = application as WalletApplication
+
+    fun checkPin(pin : String) {
+        if (deriveKeyTask == null) {
+            deriveKeyTask = object : DeriveKeyTask(backgroundHandler, walletApplication.scryptIterationsTarget()) {
+
+                override fun onSuccess(encryptionKey: KeyParameter, changed: Boolean) {
+                    deriveKeyTask = null
+                    if (decryptSeedTask == null) {
+                        decryptSeedTask = object : DecryptSeedTask(backgroundHandler) {
+
+                            override fun onBadPassphrase() {
+                                value = Resource.error("wrong password", Pair(walletApplication.wallet.keyChainSeed, pin))
+                                decryptSeedTask = null
+                            }
+
+                            override fun onSuccess(seed : DeterministicSeed) {
+                                value = Resource.success(Pair(seed, pin))
+                                decryptSeedTask = null
+                            }
+                        }
+                        value = Resource.loading(null)
+                        decryptSeedTask!!.decryptSeed(walletApplication.wallet.keyChainSeed, walletApplication.wallet.keyCrypter, encryptionKey)
+                    }
+                }
+            }
+            value = Resource.loading(null)
+            deriveKeyTask!!.deriveKey(walletApplication.wallet, pin)
+        }
+    }
+}

--- a/wallet/src/de/schildbach/wallet/ui/BackupWalletToSeedDialogFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/BackupWalletToSeedDialogFragment.java
@@ -258,7 +258,7 @@ public class BackupWalletToSeedDialogFragment extends DialogFragment
         List<String> mnemonicCode = seed.getMnemonicCode();
         String[] seedArr = new String[mnemonicCode.size()];
         seedArr = mnemonicCode.toArray(seedArr);
-        Intent intent = VerifySeedActivity.Companion.createIntent(activity, seedArr);
+        Intent intent = VerifySeedActivity.Companion.createIntent(activity, seedArr, true);
         startActivity(intent);
     }
 

--- a/wallet/src/de/schildbach/wallet/ui/BackupWalletToSeedDialogFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/BackupWalletToSeedDialogFragment.java
@@ -258,7 +258,7 @@ public class BackupWalletToSeedDialogFragment extends DialogFragment
         List<String> mnemonicCode = seed.getMnemonicCode();
         String[] seedArr = new String[mnemonicCode.size()];
         seedArr = mnemonicCode.toArray(seedArr);
-        Intent intent = VerifySeedActivity.Companion.createIntent(activity, seedArr, true);
+        Intent intent = VerifySeedActivity.Companion.createIntent(activity, seedArr);
         startActivity(intent);
     }
 

--- a/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
+++ b/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
@@ -17,6 +17,7 @@ import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.CancellationSignal
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import de.schildbach.wallet.livedata.Status
@@ -183,8 +184,12 @@ open class CheckPinDialog : DialogFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         activity?.run {
-            sharedModel = ViewModelProviders.of(this)[CheckPinSharedModel::class.java]
+            initSharedModel()
         } ?: throw IllegalStateException("Invalid Activity")
+    }
+
+    protected open fun FragmentActivity.initSharedModel() {
+        sharedModel = ViewModelProviders.of(this)[CheckPinSharedModel::class.java]
     }
 
     protected fun setState(newState: State) {
@@ -255,11 +260,11 @@ open class CheckPinDialog : DialogFragment() {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.M)
-    protected open fun startFingerprintListener() {
+    private fun startFingerprintListener() {
         fingerprintCancellationSignal = CancellationSignal()
         fingerprintHelper!!.getPassword(fingerprintCancellationSignal, object : FingerprintHelper.Callback {
             override fun onSuccess(savedPass: String) {
-                dismiss(savedPass)
+                onFingerprintSuccess(savedPass)
             }
 
             override fun onFailure(message: String, canceled: Boolean, exceededMaxAttempts: Boolean) {
@@ -272,6 +277,10 @@ open class CheckPinDialog : DialogFragment() {
                 fingerprint_view.showError(false)
             }
         })
+    }
+
+    protected open fun onFingerprintSuccess(savedPass: String) {
+        dismiss(savedPass)
     }
 
     protected fun showLockedAlert(context: Context) {

--- a/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
+++ b/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
@@ -27,7 +27,7 @@ import de.schildbach.wallet_test.R
 import kotlinx.android.synthetic.main.fragment_enter_pin.*
 
 
-class CheckPinDialog : DialogFragment() {
+open class CheckPinDialog : DialogFragment() {
 
     companion object {
 
@@ -59,14 +59,14 @@ class CheckPinDialog : DialogFragment() {
 
     private lateinit var state: State
 
-    private lateinit var viewModel: CheckPinViewModel
-    private lateinit var sharedModel: CheckPinSharedModel
+    protected lateinit var viewModel: CheckPinViewModel
+    protected lateinit var sharedModel: CheckPinSharedModel
 
-    private val pinRetryController = PinRetryController.getInstance()
+    protected val pinRetryController = PinRetryController.getInstance()
     private var fingerprintHelper: FingerprintHelper? = null
     private lateinit var fingerprintCancellationSignal: CancellationSignal
 
-    private enum class State {
+    protected enum class State {
         ENTER_PIN,
         INVALID_PIN,
         DECRYPTING
@@ -84,26 +84,7 @@ class CheckPinDialog : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel = ViewModelProviders.of(this).get(CheckPinViewModel::class.java)
-        viewModel.checkPinLiveData.observe(viewLifecycleOwner, Observer {
-            when (it.status) {
-                Status.ERROR -> {
-                    pinRetryController.failedAttempt(it.data!!)
-                    if (pinRetryController.isLocked) {
-                        showLockedAlert(context!!)
-                        dismiss()
-                        return@Observer
-                    }
-                    setState(State.INVALID_PIN)
-                }
-                Status.LOADING -> {
-                    setState(State.DECRYPTING)
-                }
-                Status.SUCCESS -> {
-                    dismiss(it.data!!)
-                }
-            }
-        })
+        initViewModel()
         cancel_button.setOnClickListener {
             sharedModel.onCancelCallback.call()
             dismiss()
@@ -154,6 +135,33 @@ class CheckPinDialog : DialogFragment() {
         }
     }
 
+    /*
+        initViewModel can be overridden by subclasses to specify their own view model
+        and actions
+     */
+    protected open fun initViewModel() {
+        viewModel = ViewModelProviders.of(this).get(CheckPinViewModel::class.java)
+        viewModel.checkPinLiveData.observe(viewLifecycleOwner, Observer {
+            when (it.status) {
+                Status.ERROR -> {
+                    pinRetryController.failedAttempt(it.data!!)
+                    if (pinRetryController.isLocked) {
+                        showLockedAlert(context!!)
+                        dismiss()
+                        return@Observer
+                    }
+                    setState(State.INVALID_PIN)
+                }
+                Status.LOADING -> {
+                    setState(State.DECRYPTING)
+                }
+                Status.SUCCESS -> {
+                    dismiss(it.data!!)
+                }
+            }
+        })
+    }
+
     private fun dismiss(pin: String) {
         if (pinRetryController.isLocked) {
             return
@@ -179,7 +187,7 @@ class CheckPinDialog : DialogFragment() {
         } ?: throw IllegalStateException("Invalid Activity")
     }
 
-    private fun setState(newState: State) {
+    protected fun setState(newState: State) {
         when (newState) {
             State.ENTER_PIN -> {
                 if (pin_progress_switcher.currentView.id == R.id.progress) {
@@ -266,7 +274,7 @@ class CheckPinDialog : DialogFragment() {
         })
     }
 
-    private fun showLockedAlert(context: Context) {
+    protected fun showLockedAlert(context: Context) {
         val dialogBuilder = AlertDialog.Builder(context)
         dialogBuilder.setTitle(R.string.wallet_lock_wallet_disabled)
         dialogBuilder.setMessage(pinRetryController.getWalletTemporaryLockedMessage(context))

--- a/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
+++ b/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
@@ -184,12 +184,12 @@ open class CheckPinDialog : DialogFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         activity?.run {
-            initSharedModel()
+            initSharedModel(this)
         } ?: throw IllegalStateException("Invalid Activity")
     }
 
-    protected open fun FragmentActivity.initSharedModel() {
-        sharedModel = ViewModelProviders.of(this)[CheckPinSharedModel::class.java]
+    protected open fun FragmentActivity.initSharedModel(activity: FragmentActivity) {
+        sharedModel = ViewModelProviders.of(activity)[CheckPinSharedModel::class.java]
     }
 
     protected fun setState(newState: State) {

--- a/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
+++ b/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
@@ -63,8 +63,8 @@ open class CheckPinDialog : DialogFragment() {
     protected lateinit var sharedModel: CheckPinSharedModel
 
     protected val pinRetryController = PinRetryController.getInstance()
-    private var fingerprintHelper: FingerprintHelper? = null
-    private lateinit var fingerprintCancellationSignal: CancellationSignal
+    protected var fingerprintHelper: FingerprintHelper? = null
+    protected lateinit var fingerprintCancellationSignal: CancellationSignal
 
     protected enum class State {
         ENTER_PIN,
@@ -255,7 +255,7 @@ open class CheckPinDialog : DialogFragment() {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.M)
-    private fun startFingerprintListener() {
+    protected open fun startFingerprintListener() {
         fingerprintCancellationSignal = CancellationSignal()
         fingerprintHelper!!.getPassword(fingerprintCancellationSignal, object : FingerprintHelper.Callback {
             override fun onSuccess(savedPass: String) {

--- a/wallet/src/de/schildbach/wallet/ui/CheckPinSharedModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/CheckPinSharedModel.kt
@@ -19,7 +19,7 @@ package de.schildbach.wallet.ui
 import androidx.lifecycle.ViewModel
 
 
-class CheckPinSharedModel : ViewModel() {
+open class CheckPinSharedModel : ViewModel() {
 
     val onCorrectPinCallback = SingleLiveEventExt<Pair<Int, String>>()
 

--- a/wallet/src/de/schildbach/wallet/ui/CheckPinViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/CheckPinViewModel.kt
@@ -22,17 +22,17 @@ import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet.livedata.CheckPinLiveData
 import org.slf4j.LoggerFactory
 
-class CheckPinViewModel(application: Application) : AndroidViewModel(application) {
+open class CheckPinViewModel(application: Application) : AndroidViewModel(application) {
 
     private val log = LoggerFactory.getLogger(CheckPinViewModel::class.java)
 
-    val walletApplication = application as WalletApplication
+    protected val walletApplication = application as WalletApplication
 
     val pin = StringBuilder()
 
     internal val checkPinLiveData = CheckPinLiveData(application)
 
-    fun checkPin(password: CharSequence) {
+    open fun checkPin(password: CharSequence) {
         if (walletApplication.wallet.isEncrypted) {
             checkPinLiveData.checkPin(password.toString())
         } else {

--- a/wallet/src/de/schildbach/wallet/ui/DecryptSeedSharedModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/DecryptSeedSharedModel.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Dash Core Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.schildbach.wallet.ui
+
+import org.bitcoinj.wallet.DeterministicSeed
+
+/**
+ * @author:  Eric Britten
+ */
+
+class DecryptSeedSharedModel : CheckPinSharedModel() {
+    val onDecryptSeedCallback = SingleLiveEventExt<Pair<Int?, DeterministicSeed?>>()
+}

--- a/wallet/src/de/schildbach/wallet/ui/DecryptSeedViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/DecryptSeedViewModel.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Dash Core Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.schildbach.wallet.ui
+
+import android.app.Application
+import de.schildbach.wallet.livedata.DecryptSeedLiveData
+import org.slf4j.LoggerFactory
+
+/**
+ * @author:  Eric Britten
+ */
+
+class DecryptSeedViewModel(application: Application) : CheckPinViewModel(application) {
+
+    private val log = LoggerFactory.getLogger(DecryptSeedViewModel::class.java)
+
+    internal val decryptSeedLiveData = DecryptSeedLiveData(application)
+
+    override fun checkPin(password: CharSequence) {
+        if (walletApplication.wallet.isEncrypted) {
+            decryptSeedLiveData.checkPin(password.toString())
+        } else {
+            log.warn("Trying to decrypt unencrypted wallet")
+        }
+    }
+}

--- a/wallet/src/de/schildbach/wallet/ui/DecryptSeedWithPinDialog.kt
+++ b/wallet/src/de/schildbach/wallet/ui/DecryptSeedWithPinDialog.kt
@@ -1,0 +1,88 @@
+package de.schildbach.wallet.ui
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProviders
+import de.schildbach.wallet.livedata.Status
+import de.schildbach.wallet.ui.preference.PinRetryController
+import org.bitcoinj.wallet.DeterministicSeed
+
+/**
+ * @author:  Eric Britten
+ *
+ * DecryptSeedWithPinDialog uses DecryptSeedSharedModel which is derived
+ * from CheckPinShared model but does not call the onCorrectPinCallback
+ * event
+ */
+
+class DecryptSeedWithPinDialog : CheckPinDialog() {
+
+    companion object {
+
+        private val FRAGMENT_TAG = DecryptSeedWithPinDialog::class.java.simpleName
+
+        private const val ARG_REQUEST_CODE = "arg_request_code"
+        private const val ARG_PIN_ONLY = "arg_pin_only"
+
+        @JvmStatic
+        fun show(activity: AppCompatActivity, requestCode: Int = 0, pinOnly: Boolean = false) {
+            val checkPinDialog = DecryptSeedWithPinDialog()
+            if (PinRetryController.getInstance().isLocked) {
+                checkPinDialog.showLockedAlert(activity)
+            } else {
+                val args = Bundle()
+                args.putInt(ARG_REQUEST_CODE, requestCode)
+                args.putBoolean(ARG_PIN_ONLY, pinOnly)
+                checkPinDialog.arguments = args
+                checkPinDialog.show(activity.supportFragmentManager, FRAGMENT_TAG)
+            }
+        }
+
+        @JvmStatic
+        fun show(activity: AppCompatActivity, requestCode: Int = 0) {
+            show(activity, requestCode, false)
+        }
+
+    }
+
+    override fun initViewModel() {
+        viewModel = ViewModelProviders.of(this).get(DecryptSeedViewModel::class.java)
+        (viewModel as DecryptSeedViewModel).decryptSeedLiveData.observe(viewLifecycleOwner, Observer {
+            when (it.status) {
+                Status.ERROR -> {
+                    pinRetryController.failedAttempt(it.data!!.second!!)
+                    if (pinRetryController.isLocked) {
+                        showLockedAlert(context!!)
+                        dismiss()
+                        return@Observer
+                    }
+                    setState(State.INVALID_PIN)
+                }
+                Status.LOADING -> {
+                    setState(State.DECRYPTING)
+                }
+                Status.SUCCESS -> {
+                    dismiss(it.data!!.first!!, it.data!!.second!!)
+                }
+            }
+        })
+    }
+
+    private fun dismiss(seed : DeterministicSeed, pin: String) {
+        if (pinRetryController.isLocked) {
+            return
+        }
+        val requestCode = arguments!!.getInt(ARG_REQUEST_CODE)
+        (sharedModel as DecryptSeedSharedModel).onDecryptSeedCallback.value = Pair(requestCode, seed)
+        pinRetryController.clearPinFailPrefs()
+        dismiss()
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        activity?.run {
+            sharedModel = ViewModelProviders.of(this)[DecryptSeedSharedModel::class.java]
+        } ?: throw IllegalStateException("Invalid Activity")
+    }
+}

--- a/wallet/src/de/schildbach/wallet/ui/DecryptSeedWithPinDialog.kt
+++ b/wallet/src/de/schildbach/wallet/ui/DecryptSeedWithPinDialog.kt
@@ -1,10 +1,8 @@
 package de.schildbach.wallet.ui
 
-import android.os.Build
 import android.os.Bundle
-import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.os.CancellationSignal
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import de.schildbach.wallet.livedata.Status
@@ -84,31 +82,11 @@ class DecryptSeedWithPinDialog : CheckPinDialog() {
         dismiss()
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        activity?.run {
-            sharedModel = ViewModelProviders.of(this)[DecryptSeedSharedModel::class.java]
-        } ?: throw IllegalStateException("Invalid Activity")
+    override fun FragmentActivity.initSharedModel() {
+        sharedModel = ViewModelProviders.of(this)[DecryptSeedSharedModel::class.java]
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.M)
-    override fun startFingerprintListener() {
-        fingerprintCancellationSignal = CancellationSignal()
-        fingerprintHelper!!.getPassword(fingerprintCancellationSignal, object : FingerprintHelper.Callback {
-            override fun onSuccess(savedPass: String) {
-                //dismiss(savedPass)
-                (viewModel as DecryptSeedViewModel).checkPin(savedPass)
-            }
-
-            override fun onFailure(message: String, canceled: Boolean, exceededMaxAttempts: Boolean) {
-                if (!canceled) {
-                    fingerprint_view.showError(exceededMaxAttempts)
-                }
-            }
-
-            override fun onHelp(helpCode: Int, helpString: String) {
-                fingerprint_view.showError(false)
-            }
-        })
+    override fun onFingerprintSuccess(savedPass : String) {
+        (viewModel as DecryptSeedViewModel).checkPin(savedPass)
     }
 }

--- a/wallet/src/de/schildbach/wallet/ui/DecryptSeedWithPinDialog.kt
+++ b/wallet/src/de/schildbach/wallet/ui/DecryptSeedWithPinDialog.kt
@@ -82,8 +82,8 @@ class DecryptSeedWithPinDialog : CheckPinDialog() {
         dismiss()
     }
 
-    override fun FragmentActivity.initSharedModel() {
-        sharedModel = ViewModelProviders.of(this)[DecryptSeedSharedModel::class.java]
+    override fun FragmentActivity.initSharedModel(activity: FragmentActivity) {
+        sharedModel = ViewModelProviders.of(activity)[DecryptSeedSharedModel::class.java]
     }
 
     override fun onFingerprintSuccess(savedPass : String) {

--- a/wallet/src/de/schildbach/wallet/ui/SecurityActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SecurityActivity.kt
@@ -40,8 +40,6 @@ class SecurityActivity : BaseMenuActivity(), AbstractPINDialogFragment.WalletPro
 
     private lateinit var fingerprintHelper: FingerprintHelper
     private lateinit var checkPinSharedModel: CheckPinSharedModel
-    private lateinit var decryptSeedViewModel2: DecryptSeedViewModel2
-
 
     companion object {
         private const val AUTH_REQUEST_CODE_BACKUP = 1

--- a/wallet/src/de/schildbach/wallet/ui/SecurityActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SecurityActivity.kt
@@ -72,7 +72,7 @@ class SecurityActivity : BaseMenuActivity(), AbstractPINDialogFragment.WalletPro
                     if (ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED) {
                         BackupWalletDialogFragment.show(supportFragmentManager)
                     } else {
-                        ActivityCompat.requestPermissions(this, arrayOf(permission), 1)
+                        ActivityCompat.requestPermissions(this, arrayOf(permission), AUTH_REQUEST_CODE_BACKUP)
                     }
                 }
                 ENABLE_FINGERPRINT_REQUEST_CODE -> {
@@ -156,5 +156,14 @@ class SecurityActivity : BaseMenuActivity(), AbstractPINDialogFragment.WalletPro
         var seedArray = mnemonicCode!!.toTypedArray()
         val intent = ViewSeedActivity.createIntent(this, seedArray)
         startActivity(intent)
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>,
+                                            grantResults: IntArray) {
+        if (requestCode == AUTH_REQUEST_CODE_BACKUP) {
+            if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)
+                BackupWalletDialogFragment.show(supportFragmentManager)
+
+        }
     }
 }

--- a/wallet/src/de/schildbach/wallet/ui/SecurityActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SecurityActivity.kt
@@ -84,8 +84,14 @@ class SecurityActivity : BaseMenuActivity(), AbstractPINDialogFragment.WalletPro
                 FINGERPRINT_ENABLED_REQUEST_CODE -> {
                     updateFingerprintSwitchSilently(fingerprintHelper.isFingerprintEnabled)
                 }
+            }
+        })
+
+        val decryptSeedSharedModel : DecryptSeedSharedModel = ViewModelProviders.of(this).get(DecryptSeedSharedModel::class.java)
+        decryptSeedSharedModel.onDecryptSeedCallback.observe(this, Observer<Pair<Int?, DeterministicSeed?>> { (requestCode, seed) ->
+            when (requestCode) {
                 AUTH_REQUEST_CODE_VIEW_RECOVERYPHRASE -> {
-                    viewRecoveryPhrase(pin)
+                    startVerifySeedActivity(seed)
                 }
             }
         })
@@ -121,7 +127,6 @@ class SecurityActivity : BaseMenuActivity(), AbstractPINDialogFragment.WalletPro
     }
 
     fun viewRecoveryPhrase(view: View) {
-        //CheckPinDialog.show(this, AUTH_REQUEST_CODE_VIEW_RECOVERYPHRASE)
         DecryptSeedWithPinDialog.show(this, AUTH_REQUEST_CODE_VIEW_RECOVERYPHRASE)
     }
 
@@ -146,20 +151,10 @@ class SecurityActivity : BaseMenuActivity(), AbstractPINDialogFragment.WalletPro
         return WalletApplication.getInstance().wallet
     }
 
-    fun viewRecoveryPhrase(pin : String?) {
-
-        decryptSeedViewModel2 = DecryptSeedViewModel2(walletApplication)
-
-        decryptSeedViewModel2.processDecryptedSeed.observe(this, Observer { seed -> startVerifySeedActivity(seed) })
-
-        decryptSeedViewModel2.decryptSeed(pin)
-
-    }
-
-    fun startVerifySeedActivity(seed : DeterministicSeed) {
-        val mnemonicCode = seed.mnemonicCode
+    fun startVerifySeedActivity(seed : DeterministicSeed?) {
+        val mnemonicCode = seed!!.mnemonicCode
         var seedArray = mnemonicCode!!.toTypedArray()
-        val intent = VerifySeedActivity.createIntent(this, seedArray, true)
+        val intent = ViewSeedActivity.createIntent(this, seedArray)
         startActivity(intent)
     }
 }

--- a/wallet/src/de/schildbach/wallet/ui/SecurityActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SecurityActivity.kt
@@ -48,6 +48,7 @@ class SecurityActivity : BaseMenuActivity(), AbstractPINDialogFragment.WalletPro
         private const val ENABLE_FINGERPRINT_REQUEST_CODE = 2
         private const val FINGERPRINT_ENABLED_REQUEST_CODE = 3
         private const val AUTH_REQUEST_CODE_VIEW_RECOVERYPHRASE = 4
+        private const val AUTH_REQUEST_CODE_ADVANCED_SECURITY = 5
     }
 
     override fun getLayoutId(): Int {
@@ -83,6 +84,9 @@ class SecurityActivity : BaseMenuActivity(), AbstractPINDialogFragment.WalletPro
                 }
                 FINGERPRINT_ENABLED_REQUEST_CODE -> {
                     updateFingerprintSwitchSilently(fingerprintHelper.isFingerprintEnabled)
+                }
+                AUTH_REQUEST_CODE_ADVANCED_SECURITY -> {
+                    startActivity(Intent(this, AdvancedSecurityActivity::class.java))
                 }
             }
         })
@@ -135,7 +139,7 @@ class SecurityActivity : BaseMenuActivity(), AbstractPINDialogFragment.WalletPro
     }
 
     fun openAdvancedSecurity(view: View) {
-        startActivity(Intent(this, AdvancedSecurityActivity::class.java))
+        CheckPinDialog.show(this, AUTH_REQUEST_CODE_ADVANCED_SECURITY)
     }
 
     fun resetWallet(view: View) {
@@ -151,7 +155,7 @@ class SecurityActivity : BaseMenuActivity(), AbstractPINDialogFragment.WalletPro
         return WalletApplication.getInstance().wallet
     }
 
-    fun startVerifySeedActivity(seed : DeterministicSeed?) {
+    private fun startVerifySeedActivity(seed : DeterministicSeed?) {
         val mnemonicCode = seed!!.mnemonicCode
         var seedArray = mnemonicCode!!.toTypedArray()
         val intent = ViewSeedActivity.createIntent(this, seedArray)

--- a/wallet/src/de/schildbach/wallet/ui/SecurityActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SecurityActivity.kt
@@ -93,7 +93,7 @@ class SecurityActivity : BaseMenuActivity(), AbstractPINDialogFragment.WalletPro
         decryptSeedSharedModel.onDecryptSeedCallback.observe(this, Observer<Pair<Int?, DeterministicSeed?>> { (requestCode, seed) ->
             when (requestCode) {
                 AUTH_REQUEST_CODE_VIEW_RECOVERYPHRASE -> {
-                    startVerifySeedActivity(seed)
+                    startViewSeedActivity(seed)
                 }
             }
         })
@@ -125,11 +125,11 @@ class SecurityActivity : BaseMenuActivity(), AbstractPINDialogFragment.WalletPro
     }
 
     fun backupWallet(view: View) {
-        CheckPinDialog.show(this, AUTH_REQUEST_CODE_BACKUP)
+        CheckPinDialog.show(this, AUTH_REQUEST_CODE_BACKUP, true)
     }
 
     fun viewRecoveryPhrase(view: View) {
-        DecryptSeedWithPinDialog.show(this, AUTH_REQUEST_CODE_VIEW_RECOVERYPHRASE)
+        DecryptSeedWithPinDialog.show(this, AUTH_REQUEST_CODE_VIEW_RECOVERYPHRASE, true)
     }
 
     fun changePin(view: View) {
@@ -137,7 +137,7 @@ class SecurityActivity : BaseMenuActivity(), AbstractPINDialogFragment.WalletPro
     }
 
     fun openAdvancedSecurity(view: View) {
-        CheckPinDialog.show(this, AUTH_REQUEST_CODE_ADVANCED_SECURITY)
+        CheckPinDialog.show(this, AUTH_REQUEST_CODE_ADVANCED_SECURITY, true)
     }
 
     fun resetWallet(view: View) {
@@ -153,7 +153,7 @@ class SecurityActivity : BaseMenuActivity(), AbstractPINDialogFragment.WalletPro
         return WalletApplication.getInstance().wallet
     }
 
-    private fun startVerifySeedActivity(seed : DeterministicSeed?) {
+    private fun startViewSeedActivity(seed : DeterministicSeed?) {
         val mnemonicCode = seed!!.mnemonicCode
         var seedArray = mnemonicCode!!.toTypedArray()
         val intent = ViewSeedActivity.createIntent(this, seedArray)

--- a/wallet/src/de/schildbach/wallet/ui/VerifySeedActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/VerifySeedActivity.kt
@@ -32,18 +32,15 @@ class VerifySeedActivity : AppCompatActivity(), VerifySeedActions {
     companion object {
 
         private const val EXTRA_SEED = "extra_seed"
-        private const val EXTRA_VIEW_ONLY = "extra_write_down"
 
-        fun createIntent(context: Context, seed: Array<String>, viewOnly: Boolean = false): Intent {
+        fun createIntent(context: Context, seed: Array<String>): Intent {
             val intent = Intent(context, VerifySeedActivity::class.java)
             intent.putExtra(EXTRA_SEED, seed)
-            intent.putExtra(EXTRA_VIEW_ONLY, viewOnly)
             return intent
         }
     }
 
     private var seed: Array<String> = arrayOf()
-    private var viewOnly = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -55,19 +52,9 @@ class VerifySeedActivity : AppCompatActivity(), VerifySeedActions {
             throw IllegalStateException("This activity needs to receive a String[] Intent Extra " +
                     "containing the recovery seed.")
         }
-        viewOnly = if(intent.extras.containsKey(EXTRA_VIEW_ONLY)) {
-            intent.extras!!.getBoolean(EXTRA_VIEW_ONLY)!!
-        } else {
-            false
-        }
 
-        if(viewOnly) {
-            supportFragmentManager.beginTransaction().add(R.id.container,
-                    VerifySeedWriteDownFragment.newInstance(seed)).commit()
-        } else {
-            supportFragmentManager.beginTransaction().add(R.id.container,
+        supportFragmentManager.beginTransaction().add(R.id.container,
                     VerifySeedSecureNowFragment.newInstance()).commit()
-        }
     }
 
     private fun replaceFragment(fragment: Fragment) {
@@ -91,12 +78,8 @@ class VerifySeedActivity : AppCompatActivity(), VerifySeedActions {
     }
 
     override fun onVerifyWriteDown() {
-        if(viewOnly) {
-            goHome()
-        } else {
             supportFragmentManager.beginTransaction().replace(R.id.container,
                     VerifySeedConfirmFragment.newInstance(seed)).commit()
-        }
     }
 
     override fun onSeedVerified() {

--- a/wallet/src/de/schildbach/wallet/ui/VerifySeedActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/VerifySeedActivity.kt
@@ -32,15 +32,18 @@ class VerifySeedActivity : AppCompatActivity(), VerifySeedActions {
     companion object {
 
         private const val EXTRA_SEED = "extra_seed"
+        private const val EXTRA_VIEW_ONLY = "extra_write_down"
 
-        fun createIntent(context: Context, seed: Array<String>): Intent {
+        fun createIntent(context: Context, seed: Array<String>, viewOnly: Boolean = false): Intent {
             val intent = Intent(context, VerifySeedActivity::class.java)
             intent.putExtra(EXTRA_SEED, seed)
+            intent.putExtra(EXTRA_VIEW_ONLY, viewOnly)
             return intent
         }
     }
 
     private var seed: Array<String> = arrayOf()
+    private var viewOnly = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -52,9 +55,19 @@ class VerifySeedActivity : AppCompatActivity(), VerifySeedActions {
             throw IllegalStateException("This activity needs to receive a String[] Intent Extra " +
                     "containing the recovery seed.")
         }
+        viewOnly = if(intent.extras.containsKey(EXTRA_VIEW_ONLY)) {
+            intent.extras!!.getBoolean(EXTRA_VIEW_ONLY)!!
+        } else {
+            false
+        }
 
-        supportFragmentManager.beginTransaction().add(R.id.container,
-                VerifySeedSecureNowFragment.newInstance()).commit()
+        if(viewOnly) {
+            supportFragmentManager.beginTransaction().add(R.id.container,
+                    VerifySeedWriteDownFragment.newInstance(seed)).commit()
+        } else {
+            supportFragmentManager.beginTransaction().add(R.id.container,
+                    VerifySeedSecureNowFragment.newInstance()).commit()
+        }
     }
 
     private fun replaceFragment(fragment: Fragment) {
@@ -78,8 +91,12 @@ class VerifySeedActivity : AppCompatActivity(), VerifySeedActions {
     }
 
     override fun onVerifyWriteDown() {
-        supportFragmentManager.beginTransaction().replace(R.id.container,
-                VerifySeedConfirmFragment.newInstance(seed)).commit()
+        if(viewOnly) {
+            goHome()
+        } else {
+            supportFragmentManager.beginTransaction().replace(R.id.container,
+                    VerifySeedConfirmFragment.newInstance(seed)).commit()
+        }
     }
 
     override fun onSeedVerified() {

--- a/wallet/src/de/schildbach/wallet/ui/VerifySeedActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/VerifySeedActivity.kt
@@ -33,6 +33,7 @@ class VerifySeedActivity : AppCompatActivity(), VerifySeedActions {
 
         private const val EXTRA_SEED = "extra_seed"
 
+        @JvmStatic
         fun createIntent(context: Context, seed: Array<String>): Intent {
             val intent = Intent(context, VerifySeedActivity::class.java)
             intent.putExtra(EXTRA_SEED, seed)

--- a/wallet/src/de/schildbach/wallet/ui/ViewSeedActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/ViewSeedActivity.kt
@@ -56,12 +56,9 @@ class ViewSeedActivity : BaseMenuActivity() {
                     "containing the recovery seed.")
         }
 
-        val sb = StringBuilder(12)
-        seed.forEach {
-            sb.append("$it  ")
-        }
+        val sb = seed.joinToString(" ")
 
-        recovery_seed.text = sb.toString().trim()
+        recovery_seed.text = sb.trim()
 
         confirm_btn.setOnClickListener {
            finish()

--- a/wallet/src/de/schildbach/wallet/ui/ViewSeedActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/ViewSeedActivity.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 Dash Core Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.schildbach.wallet.ui
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import de.schildbach.wallet.WalletApplication
+import de.schildbach.wallet_test.R
+import kotlinx.android.synthetic.main.activity_view_seed.*
+
+/**
+ * @author Eric Britten
+ */
+class ViewSeedActivity : BaseMenuActivity() {
+
+    companion object {
+
+        private const val EXTRA_SEED = "extra_seed"
+
+        fun createIntent(context: Context, seed: Array<String>): Intent {
+            val intent = Intent(context, ViewSeedActivity::class.java)
+            intent.putExtra(EXTRA_SEED, seed)
+            return intent
+        }
+    }
+
+    override fun getLayoutId(): Int {
+        return R.layout.activity_view_seed
+    }
+
+    private var seed: Array<String> = arrayOf()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        //setContentView(R.layout.activity_verify_seed)
+
+        seed = if (intent.extras?.containsKey(EXTRA_SEED)!!) {
+            intent.extras!!.getStringArray(EXTRA_SEED)!!
+        } else {
+            throw IllegalStateException("This activity needs to receive a String[] Intent Extra " +
+                    "containing the recovery seed.")
+        }
+
+        val sb = StringBuilder(12)
+        seed.forEach {
+            sb.append("$it  ")
+        }
+
+        recovery_seed.text = sb.toString().trim()
+
+        confirm_btn.setOnClickListener {
+           finish()
+        }
+
+        setTitle(R.string.view_seed_title)
+    }
+
+    override fun onBackPressed() {
+        finish()
+    }
+
+    override fun onUserInteraction() {
+        (application as WalletApplication).resetAutoLogoutTimer()
+    }
+
+    //override fun finish() {
+    //    super.finish()
+    //    overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right)
+    //}
+}

--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -554,7 +554,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
     private void startVerifySeedActivity(DeterministicSeed seed) {
         List<String> mnemonicCode = seed.getMnemonicCode();
         String [] seedArray = mnemonicCode.toArray(new String[0]);
-        Intent intent = VerifySeedActivity.Companion.createIntent(this, seedArray);
+        Intent intent = VerifySeedActivity.createIntent(this, seedArray);
         startActivity(intent);
     }
 

--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -67,6 +67,7 @@ import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.crypto.ChildNumber;
+import org.bitcoinj.wallet.DeterministicSeed;
 import org.bitcoinj.wallet.Wallet;
 import org.dash.wallet.common.Configuration;
 import org.dash.wallet.common.ui.DialogBuilder;
@@ -78,6 +79,7 @@ import org.greenrobot.eventbus.ThreadMode;
 
 import java.io.IOException;
 import java.util.Currency;
+import java.util.List;
 import java.util.Locale;
 
 import de.schildbach.wallet.Constants;
@@ -176,7 +178,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
         this.clipboardManager = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
 
         if (config.remindBackupSeed() && config.lastDismissedReminderMoreThan24hAgo()) {
-            BackupWalletToSeedDialogFragment.show(getSupportFragmentManager());
+            handleVerifySeed();
         }
 
         View appBar = findViewById(R.id.app_bar);
@@ -529,7 +531,31 @@ public final class WalletActivity extends AbstractBindServiceActivity
     }
 
     public void handleBackupWalletToSeed() {
-        BackupWalletToSeedDialogFragment.show(getSupportFragmentManager());
+        handleVerifySeed();
+    }
+
+    private void handleVerifySeed() {
+        final int AUTH_REQUEST_CODE_VIEW_RECOVERYPHRASE = 1;
+        DecryptSeedSharedModel decryptSeedSharedModel = ViewModelProviders.of(this).get(DecryptSeedSharedModel.class);
+        decryptSeedSharedModel.getOnDecryptSeedCallback().observe(this, new Observer<Pair<Integer, DeterministicSeed>>() {
+
+            @Override
+            public void onChanged(Pair<Integer, DeterministicSeed> data) {
+                switch (data.getFirst()) {
+                    case AUTH_REQUEST_CODE_VIEW_RECOVERYPHRASE:
+                        startVerifySeedActivity(data.getSecond());
+                        break;
+                }
+            }
+        });
+        DecryptSeedWithPinDialog.show(this, AUTH_REQUEST_CODE_VIEW_RECOVERYPHRASE);
+    }
+
+    private void startVerifySeedActivity(DeterministicSeed seed) {
+        List<String> mnemonicCode = seed.getMnemonicCode();
+        String [] seedArray = mnemonicCode.toArray(new String[0]);
+        Intent intent = VerifySeedActivity.Companion.createIntent(this, seedArray);
+        startActivity(intent);
     }
 
     public void handleRestoreWalletFromSeed() {


### PR DESCRIPTION
The primary focus of this PR is to use the correct design for the flow of viewing the recovery phrase.  Previously the flow was the same as the verify recovery phrase flow.

![ViewRecoveryPhrase](https://user-images.githubusercontent.com/5956129/72114678-35dad200-32f9-11ea-8c8f-768072c9daaa.png)

Additionally, the dialog was changed on the Secure Now function:

![SecureNow](https://user-images.githubusercontent.com/5956129/72114702-3d01e000-32f9-11ea-84d5-9bf13e6fd88b.png)

**Implementation:**
The CheckPinDialog was extended with a new subclass called DecryptSeedWithPinDialog while trying to maximize code reuse.  DecryptSeedWithPinDialog can use a PIN or a fingerprint to decrypt the seed that is given to the ViewSeedActivity.

I chose to derive a new class from CheckPinActivity instead of using CheckPinActivity to verify the PIN and then have a secondary set of task and screens with progress bars to perform the seed decryption with the key.

The old dialogs for decrypting the seeds are left in the app for the Wallet Upgrade processes (when a user upgrades the app from before v5.18.

This is a draft for now as there are a few questions on allowing fingerprint authentication on this feature and other security menu related items.

Additionally, this PR fixes a few things on the security menu:
1.  Back Up Wallet to File -> the first time this is run, it asks for permissions.  Then the user must click on the button again
2.  Advanced Security is put behind a CheckPinDialog