### PR TITLE
PIN finger print alignments to iOS [NMA-320]

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/Configuration.java
+++ b/common/src/main/java/org/dash/wallet/common/Configuration.java
@@ -74,6 +74,7 @@ public class Configuration {
     public static final String PREFS_KEY_BACKUP_SEED_LAST_DISMISSED_REMINDER = "backup_seed_last_dismissed_reminder";
     private static final String PREFS_KEY_LAST_BACKUP_SEED = "last_backup_seed";
     private static final String PREFS_REMIND_ENABLE_FINGERPRINT = "remind_enable_fingerprint";
+    private static final String PREFS_ENABLE_FINGERPRINT = "enable_fingerprint";
     public static final String PREFS_RESTORING_BACKUP = "restoring_backup";
 
     private static final int PREFS_DEFAULT_BTC_SHIFT = 0;
@@ -387,5 +388,13 @@ public class Configuration {
 
     public void setRemindEnableFingerprint(boolean remind) {
         prefs.edit().putBoolean(PREFS_REMIND_ENABLE_FINGERPRINT, remind).apply();
+    }
+
+    public boolean getEnableFingerprint() {
+        return prefs.getBoolean(PREFS_ENABLE_FINGERPRINT, false);
+    }
+
+    public void setEnableFingerprint(boolean remind) {
+        prefs.edit().putBoolean(PREFS_ENABLE_FINGERPRINT, remind).apply();
     }
 }

--- a/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
+++ b/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
@@ -125,14 +125,13 @@ open class CheckPinDialog : DialogFragment() {
         }
         pin_preview.setTextColor(R.color.dash_light_gray)
         pin_preview.hideForgotPinAction()
-        initFingerprint()
         setState(State.ENTER_PIN)
 
         arguments?.getBoolean(ARG_PIN_ONLY, false).let {
             if (true == it) {
                 fingerprintFlow(!it)
                 pin_or_fingerprint_button.isEnabled = false
-            }
+            } else initFingerprint()
         }
     }
 

--- a/wallet/src/de/schildbach/wallet/ui/SecurityActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SecurityActivity.kt
@@ -104,6 +104,7 @@ class SecurityActivity : BaseMenuActivity(), AbstractPINDialogFragment.WalletPro
             fingerprint_auth_group.visibility = VISIBLE
             fingerprint_auth_switch.isChecked = fingerprintHelper.isFingerprintEnabled
             fingerprint_auth_switch.setOnCheckedChangeListener(fingerprintSwitchListener)
+            configuration.enableFingerprint = true
         } else {
             fingerprint_auth_group.visibility = GONE
         }
@@ -115,6 +116,7 @@ class SecurityActivity : BaseMenuActivity(), AbstractPINDialogFragment.WalletPro
             updateFingerprintSwitchSilently(false)
         } else {
             fingerprintHelper.clear()
+            configuration.enableFingerprint = false
         }
     }
 

--- a/wallet/src/de/schildbach/wallet/ui/SetPinActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SetPinActivity.kt
@@ -338,7 +338,8 @@ class SetPinActivity : SessionActivity() {
                     } else {
                         if (changePin) {
                             saveSessionPin(viewModel.getPinAsString())
-                            if (EnableFingerprintDialog.shouldBeShown(this@SetPinActivity)) {
+                            val enableFingerprint = (application as WalletApplication).configuration.enableFingerprint
+                            if (EnableFingerprintDialog.shouldBeShown(this@SetPinActivity) && enableFingerprint) {
                                 EnableFingerprintDialog.show(viewModel.getPinAsString(), FINGERPRINT_REQUEST_CHANGE_PIN, supportFragmentManager)
                             } else {
                                 performNextStep(FINGERPRINT_REQUEST_CHANGE_PIN)


### PR DESCRIPTION
- CheckPinDialog: Enable fingerprint reading if !pinOnly
- Add enable_fingerprint preference to track state of the Fingerprint setting in Security
- SetPinActivity: Only ask user to set up fingerprint if it is enabled in Security settings