### PR TITLE
Fixed the crash when displaying SendScreenActivity

### DIFF
--- a/wallet/res/layout/send_coins_content.xml
+++ b/wallet/res/layout/send_coins_content.xml
@@ -18,7 +18,7 @@
 
     <fragment
         android:id="@+id/enter_amount_fragment"
-        android:name="org.dash.wallet.ui.EnterAmountFragment"
+        android:name="de.schildbach.wallet.ui.EnterAmountFragment"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="4"


### PR DESCRIPTION
This unintended change was made by AndroidStudio during the work on Uphold redesign and it was missed during the review.