### PR TITLE
NMA-317 wallet crashes when try to specify too big amount to Receive

### DIFF
--- a/wallet/res/layout/enter_amount_fragment.xml
+++ b/wallet/res/layout/enter_amount_fragment.xml
@@ -76,7 +76,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
+                android:ellipsize="middle"
                 android:hint="0"
+                android:singleLine="true"
                 android:textColor="@color/dash_black"
                 android:textSize="@dimen/pay_input_symbol_text_size" />
 

--- a/wallet/src/de/schildbach/wallet/ui/EnterAmountFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/EnterAmountFragment.kt
@@ -37,7 +37,6 @@ import org.dash.wallet.common.util.GenericUtils
 class EnterAmountFragment : Fragment() {
 
     companion object {
-        private const val MAX_LENGTH = 10
         private const val DECIMAL_SEPARATOR = '.'
 
         private const val ARGUMENT_INITIAL_AMOUNT = "argument_initial_amount"
@@ -91,12 +90,19 @@ class EnterAmountFragment : Fragment() {
                     // avoid entering leading zeros without decimal separator
                     return
                 }
-                val numOfDecimals = if (value.indexOf(DECIMAL_SEPARATOR) > -1) value.length - value.indexOf(DECIMAL_SEPARATOR) else 0
-                val decimalsThreshold = if (viewModel.dashToFiatDirectionValue) 6 else 2
-                if (numOfDecimals > decimalsThreshold) {
-                    return
+                val isFraction = value.indexOf(DECIMAL_SEPARATOR) > -1
+                if (isFraction) {
+                    val lengthOfDecimalPart = value.length - value.indexOf(DECIMAL_SEPARATOR)
+                    val decimalsThreshold = if (viewModel.dashToFiatDirectionValue) 6 else 2
+                    if (lengthOfDecimalPart > decimalsThreshold) {
+                        return
+                    }
+                } else {
+                    if (value.length > 5) {
+                        return
+                    }
                 }
-                if (value.length < MAX_LENGTH && !maxAmountSelected) {
+                if (!maxAmountSelected) {
                     appendIfValidAfter(number.toString())
                     applyNewValue(value.toString())
                 }
@@ -118,7 +124,7 @@ class EnterAmountFragment : Fragment() {
                     return
                 }
                 refreshValue()
-                if (value.indexOf(DECIMAL_SEPARATOR) == -1 && value.length < MAX_LENGTH) {
+                if (value.indexOf(DECIMAL_SEPARATOR) == -1) {
                     value.append(DECIMAL_SEPARATOR)
                 }
                 applyNewValue(value.toString())

--- a/wallet/src/de/schildbach/wallet/ui/EnterAmountFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/EnterAmountFragment.kt
@@ -97,14 +97,15 @@ class EnterAmountFragment : Fragment() {
                     if (lengthOfDecimalPart > decimalsThreshold) {
                         return
                     }
-                } else {
-                    if (value.length > 5) {
-                        return
-                    }
                 }
                 if (!maxAmountSelected) {
-                    appendIfValidAfter(number.toString())
-                    applyNewValue(value.toString())
+                    try {
+                        appendIfValidAfter(number.toString())
+                        applyNewValue(value.toString())
+                    } catch (x: Exception) {
+                        value.deleteCharAt(value.length - 1)
+                        applyNewValue(value.toString())
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixed by limiting the max number of decimal digits to 6 (number of decimals was already limited).