### PR TITLE
Polish up screen transitions and fix other clumsy UI/UX glitches

### DIFF
--- a/wallet/AndroidManifest.xml
+++ b/wallet/AndroidManifest.xml
@@ -271,7 +271,7 @@
 
         <activity android:name="de.schildbach.wallet.ui.WelcomeActivity"
             android:screenOrientation="portrait"
-            android:theme="@style/My.Theme.Fullscreen" />
+            android:theme="@style/LockScreenActivity.Theme" />
 
         <activity android:name="de.schildbach.wallet.ui.UpholdTransferActivity"
             android:screenOrientation="portrait"

--- a/wallet/res/layout/activity_welcome.xml
+++ b/wallet/res/layout/activity_welcome.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@drawable/splash_activity_background"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:paddingBottom="24dp"
+    tools:background="@drawable/splash_activity_background">
 
     <FrameLayout
         android:id="@+id/buttons_container"

--- a/wallet/res/values-hdpi/dimens.xml
+++ b/wallet/res/values-hdpi/dimens.xml
@@ -15,7 +15,7 @@
     <dimen name="welcome_screen_skip_size">12sp</dimen>
     <dimen name="welcome_screen_title_margin_top">20dp</dimen>
 
-    <dimen name="lock_screen_bottom_guideline_margin">0dp</dimen>
+    <dimen name="lock_screen_bottom_guideline_margin">48dp</dimen>
     <dimen name="pin_preview_textview_padding">4dp</dimen>
     <dimen name="lock_screen_content_margin_bottom">16dp</dimen>
     <dimen name="about_logo_margin_top">24dp</dimen>

--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -750,7 +750,7 @@ public class WalletApplication extends MultiDexApplication {
     private void lockTheApp(Context context, Activity activity) {
         if (!isSpecialActivity(activity)) {
             context = context.getApplicationContext();
-            Intent lockScreenIntent = LockScreenActivity.createIntent(context);
+            Intent lockScreenIntent = LockScreenActivity.createIntentAsNewTask(context);
             context.startActivity(lockScreenIntent);
         }
         deviceWasLocked = false;

--- a/wallet/src/de/schildbach/wallet/ui/LockScreenActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/LockScreenActivity.kt
@@ -50,7 +50,8 @@ class LockScreenActivity : SendCoinsQrActivity() {
         fun createIntentAsNewTask(context: Context): Intent {
             return createIntent(context)
                     .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK
-                            or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                            or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                            or Intent.FLAG_ACTIVITY_NO_ANIMATION)
         }
     }
 

--- a/wallet/src/de/schildbach/wallet/ui/LockScreenActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/LockScreenActivity.kt
@@ -160,7 +160,11 @@ class LockScreenActivity : SendCoinsQrActivity() {
                     setState(State.DECRYPTING)
                 }
                 Status.SUCCESS -> {
-                    onCorrectPin(it.data!!.first, it.data.second)
+                    if (EnableFingerprintDialog.shouldBeShown(this)) {
+                        EnableFingerprintDialog.show(it.data!!.second, supportFragmentManager)
+                    } else {
+                        onCorrectPin(it.data!!.first, it.data.second)
+                    }
                 }
             }
         })

--- a/wallet/src/de/schildbach/wallet/ui/LockScreenActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/LockScreenActivity.kt
@@ -44,6 +44,11 @@ class LockScreenActivity : SendCoinsQrActivity() {
         @JvmStatic
         fun createIntent(context: Context): Intent {
             return Intent(context, LockScreenActivity::class.java)
+        }
+
+        @JvmStatic
+        fun createIntentAsNewTask(context: Context): Intent {
+            return createIntent(context)
                     .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK
                             or Intent.FLAG_ACTIVITY_CLEAR_TASK)
         }

--- a/wallet/src/de/schildbach/wallet/ui/SetPinActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SetPinActivity.kt
@@ -321,6 +321,9 @@ class SetPinActivity : SessionActivity() {
                     } else {
                         if (state == State.DECRYPTING) {
                             setState(if (changePin) State.INVALID_PIN else State.DECRYPT)
+                            if(!changePin) {
+                                android.widget.Toast.makeText(this, "Incorrect PIN", android.widget.Toast.LENGTH_LONG).show()
+                            }
                         } else {
                             android.widget.Toast.makeText(this, "Encrypting error", android.widget.Toast.LENGTH_LONG).show()
                             setState(State.CONFIRM_PIN)

--- a/wallet/src/de/schildbach/wallet/ui/SetPinActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SetPinActivity.kt
@@ -34,16 +34,14 @@ import de.schildbach.wallet.ui.widget.NumericKeyboardView
 import de.schildbach.wallet.ui.widget.PinPreviewView
 import de.schildbach.wallet_test.R
 
-private const val FINGERPRINT_REQUEST_SEED = 1
-private const val FINGERPRINT_REQUEST_WALLET = 2
-private const val FINGERPRINT_REQUEST_CHANGE_PIN = 3
-
 class SetPinActivity : SessionActivity() {
+
+    private lateinit var walletApplication: WalletApplication
 
     private lateinit var numericKeyboardView: NumericKeyboardView
     private lateinit var confirmButtonView: View
     private lateinit var viewModel: SetPinViewModel
-    private lateinit var checkPinSharedModel: CheckPinSharedModel
+    private lateinit var enableFingerprintViewModel: CheckPinSharedModel
     private lateinit var pinProgressSwitcherView: ViewSwitcher
     private lateinit var pinPreviewView: PinPreviewView
     private lateinit var pageTitleView: TextView
@@ -107,7 +105,7 @@ class SetPinActivity : SessionActivity() {
 
         pinRetryController = PinRetryController.getInstance()
 
-        val walletApplication = application as WalletApplication
+        walletApplication = application as WalletApplication
         if (walletApplication.wallet.isEncrypted) {
             val password = intent.getStringExtra(EXTRA_PASSWORD)
             changePin = intent.getBooleanExtra(CHANGE_PIN, false)
@@ -335,17 +333,16 @@ class SetPinActivity : SessionActivity() {
                 }
                 Status.SUCCESS -> {
                     if (state == State.DECRYPTING) {
-                        val walletApplication = application as WalletApplication
                         seed = walletApplication.wallet.keyChainSeed.mnemonicCode!!
                         setState(State.SET_PIN)
                     } else {
                         if (changePin) {
                             saveSessionPin(viewModel.getPinAsString())
-                            val enableFingerprint = (application as WalletApplication).configuration.enableFingerprint
+                            val enableFingerprint = walletApplication.configuration.enableFingerprint
                             if (EnableFingerprintDialog.shouldBeShown(this@SetPinActivity) && enableFingerprint) {
-                                EnableFingerprintDialog.show(viewModel.getPinAsString(), FINGERPRINT_REQUEST_CHANGE_PIN, supportFragmentManager)
+                                EnableFingerprintDialog.show(viewModel.getPinAsString(), supportFragmentManager)
                             } else {
-                                performNextStep(FINGERPRINT_REQUEST_CHANGE_PIN)
+                                finish()
                             }
                         } else {
                             viewModel.initWallet()
@@ -375,17 +372,16 @@ class SetPinActivity : SessionActivity() {
             }
         })
         viewModel.startNextActivity.observe(this, Observer {
-
-            val requestCode = if (it) FINGERPRINT_REQUEST_SEED else FINGERPRINT_REQUEST_WALLET
-            if (EnableFingerprintDialog.shouldBeShown(this@SetPinActivity)) {
-                EnableFingerprintDialog.show(viewModel.getPinAsString(), requestCode, supportFragmentManager)
+            if (it) {
+                startVerifySeedActivity()
             } else {
-                performNextStep(requestCode)
+                goHome()
             }
+            walletApplication.maybeStartAutoLogoutTimer()
         })
-        checkPinSharedModel = ViewModelProviders.of(this).get(CheckPinSharedModel::class.java)
-        checkPinSharedModel.onCorrectPinCallback.observe(this, Observer {
-            performNextStep(it.first)
+        enableFingerprintViewModel = ViewModelProviders.of(this).get(CheckPinSharedModel::class.java)
+        enableFingerprintViewModel.onCorrectPinCallback.observe(this, Observer {
+            finish()
         })
     }
 
@@ -423,15 +419,6 @@ class SetPinActivity : SessionActivity() {
                 finish()
             }
         }
-    }
-
-    private fun performNextStep(requestCode: Int) {
-        when (requestCode) {
-            FINGERPRINT_REQUEST_SEED -> startVerifySeedActivity()
-            FINGERPRINT_REQUEST_WALLET -> goHome()
-            FINGERPRINT_REQUEST_CHANGE_PIN -> finish()
-        }
-        (application as WalletApplication).maybeStartAutoLogoutTimer()
     }
 
     private fun startVerifySeedActivity() {

--- a/wallet/src/de/schildbach/wallet/ui/TransactionResultActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/TransactionResultActivity.kt
@@ -22,7 +22,6 @@ import android.content.Intent
 import android.graphics.drawable.Animatable
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet.data.TransactionResult
 import de.schildbach.wallet.util.TransactionUtil
@@ -86,7 +85,7 @@ class TransactionResultActivity : AbstractWalletActivity() {
             if (getSessionPin() !== null) {
                 startActivity(WalletActivity.createIntent(this))
             } else {
-                startActivity(LockScreenActivity.createIntent(this))
+                startActivity(LockScreenActivity.createIntentAsNewTask(this))
             }
         }
 

--- a/wallet/src/de/schildbach/wallet/ui/WelcomeActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/WelcomeActivity.kt
@@ -75,6 +75,7 @@ class WelcomeActivity : AppCompatActivity() {
         WalletApplication.getInstance().configuration.setV7TutorialCompleted()
         setResult(Activity.RESULT_OK)
         super.finish()
+        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
     }
 
     private class WelcomePagerAdapter(fragmentManager: FragmentManager, behavior: Int,


### PR DESCRIPTION
1. Avoid screen blinking when opening the LockScreenActivity from OnboardingActivity (or to be more precise when showing LockScreen after splash screen).
2. Fix the issue that the PIN keyboard is being covered by system navigation on Krip K6 device.
3. Align background positions of WelconeActivity and LockScreenActivity to make the screen transition more fluent.
4. Disable slide-in animation when showing the LockScreenActivity during regular use.
5. (TBA)