### PR TITLE
Fixed crash when launching QR code scanner on Android 10

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/scan/ScanActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/scan/ScanActivity.java
@@ -372,7 +372,12 @@ public final class ScanActivity extends AbstractWalletActivity
                 if (nonContinuousAutoFocus)
                     cameraHandler.post(new AutoFocusRunnable(camera));
 
-                maybeTriggerSceneTransition();
+                runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        maybeTriggerSceneTransition();
+                    }
+                });
                 cameraHandler.post(fetchAndDecodeRunnable);
             } catch (final Exception x) {
                 log.info("problem opening camera", x);


### PR DESCRIPTION
Crash stacktrace:
```
2020-01-29 20:35:38.342 32414-870/hashengineering.darkcoin.wallet_test E/AndroidRuntime: FATAL EXCEPTION: cameraThread
    Process: hashengineering.darkcoin.wallet_test, PID: 32414
    android.view.ViewRootImpl$CalledFromWrongThreadException: Only the original thread that created a view hierarchy can touch its views.
        at android.view.ViewRootImpl.checkThread(ViewRootImpl.java:8198)
        at android.view.ViewRootImpl.invalidateChildInParent(ViewRootImpl.java:1467)
        at android.view.ViewRootImpl.invalidateChild(ViewRootImpl.java:1462)
```