### PR TITLE
NMA-361: Fix Localbitcoins data acquisition for Price Source Fallback #2

### DIFF
--- a/wallet/src/de/schildbach/wallet/rates/LocalBitcoinsRate.java
+++ b/wallet/src/de/schildbach/wallet/rates/LocalBitcoinsRate.java
@@ -7,37 +7,14 @@ import java.math.BigDecimal;
 public class LocalBitcoinsRate {
 
     @Json(name = "avg_1h")
-    private BigDecimal avg1h;
+    public BigDecimal avg1h;
 
     @Json(name = "avg_6h")
-    private BigDecimal avg6h;
+    public BigDecimal avg6h;
 
     @Json(name = "avg_12h")
-    private BigDecimal avg12h;
+    public BigDecimal avg12h;
 
     @Json(name = "avg_24h")
-    private BigDecimal avg24h;
-
-    public LocalBitcoinsRate(BigDecimal avg1h, BigDecimal avg6h, BigDecimal avg12h, BigDecimal avg24h) {
-        this.avg1h = avg1h;
-        this.avg6h = avg6h;
-        this.avg12h = avg12h;
-        this.avg24h = avg24h;
-    }
-
-    public BigDecimal getAvg1h() {
-        return avg1h;
-    }
-
-    public BigDecimal getAvg6h() {
-        return avg6h;
-    }
-
-    public BigDecimal getAvg12h() {
-        return avg12h;
-    }
-
-    public BigDecimal getAvg24h() {
-        return avg24h;
-    }
+    public BigDecimal avg24h;
 }

--- a/wallet/src/de/schildbach/wallet/rates/LocalBitcoinsResponse.java
+++ b/wallet/src/de/schildbach/wallet/rates/LocalBitcoinsResponse.java
@@ -14,14 +14,14 @@ public class LocalBitcoinsResponse {
     }
 
     public BigDecimal getDashVesPrice() {
-        if (localBitcoinsRate.getAvg1h() != null) {
-            return localBitcoinsRate.getAvg1h();
-        } else if (localBitcoinsRate.getAvg6h() != null) {
-            return localBitcoinsRate.getAvg6h();
-        } else if (localBitcoinsRate.getAvg12h() != null) {
-            return localBitcoinsRate.getAvg12h();
+        if (localBitcoinsRate.avg1h != null) {
+            return localBitcoinsRate.avg1h;
+        } else if (localBitcoinsRate.avg6h != null) {
+            return localBitcoinsRate.avg6h;
+        } else if (localBitcoinsRate.avg12h != null) {
+            return localBitcoinsRate.avg12h;
         } else {
-            return localBitcoinsRate.getAvg24h();
+            return localBitcoinsRate.avg24h;
         }
     }
 


### PR DESCRIPTION
This fix is taken from #297, but without update to moshi or okhttp.

This will repair Price source fallback #1 (uses Localbitcoins to get the VES price)

This will be merged into the `release-6` branch, which may later be merged to master, but for now will be separate to make merging redesign into master easier.