### PR TITLE
Redesign: Fix crashes from prelaunch report [NMA-366]

### DIFF
--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -761,8 +761,6 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
         application.getWallet().addCoinsSentEventListener(Threading.SAME_THREAD, walletEventListener);
         application.getWallet().addChangeEventListener(Threading.SAME_THREAD, walletEventListener);
 
-        application.getWallet().getContext().sporkManager.addEventListener(sporkUpdatedEventListener, Threading.SAME_THREAD);
-
         registerReceiver(tickReceiver, new IntentFilter(Intent.ACTION_TIME_TICK));
 
         wallet.getContext().initDashSync(getDir("masternode", MODE_PRIVATE).getAbsolutePath());
@@ -849,8 +847,6 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
         application.getWallet().removeChangeEventListener(walletEventListener);
         application.getWallet().removeCoinsSentEventListener(walletEventListener);
         application.getWallet().removeCoinsReceivedEventListener(walletEventListener);
-
-        application.getWallet().getContext().sporkManager.removeEventListener(sporkUpdatedEventListener);
 
         unregisterReceiver(connectivityReceiver);
 
@@ -1034,12 +1030,4 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
         log.info("mostCommonChainHeight: " + mostCommonChainHeight + "\tchainHeadHeight: " + chainHeadHeight + "\t" + percentage + "%\t" + config.getBestChainHeightEver());
         return (int) percentage;
     }
-
-    private SporkUpdatedEventListener sporkUpdatedEventListener = new SporkUpdatedEventListener() {
-
-        @Override
-        public void onSporkUpdated(final SporkMessage sporkMessage) {
-            //do nothing
-        }
-    };
 }

--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -1106,29 +1106,36 @@ public final class WalletActivity extends AbstractBindServiceActivity
         String countryCode = getCurrentCountry();
         log.info("Setting default currency:");
         if(countryCode != null) {
-            log.info("Local Country: " + countryCode);
-            Locale l = new Locale("", countryCode);
-            Currency currency = Currency.getInstance(l);
-            String newCurrencyCode = currency.getCurrencyCode();
-            if(CurrencyInfo.hasObsoleteCurrency(newCurrencyCode)) {
-                log.info("found obsolete currency: " + newCurrencyCode);
-                newCurrencyCode = CurrencyInfo.getUpdatedCurrency(newCurrencyCode);
-            }
-            log.info("Setting Local Currency: " + newCurrencyCode);
-            config.setExchangeCurrencyCode(newCurrencyCode);
+            try {
+                log.info("Local Country: " + countryCode);
+                Locale l = new Locale("", countryCode);
+                Currency currency = Currency.getInstance(l);
+                String newCurrencyCode = currency.getCurrencyCode();
+                if (CurrencyInfo.hasObsoleteCurrency(newCurrencyCode)) {
+                    log.info("found obsolete currency: " + newCurrencyCode);
+                    newCurrencyCode = CurrencyInfo.getUpdatedCurrency(newCurrencyCode);
+                }
+                log.info("Setting Local Currency: " + newCurrencyCode);
+                config.setExchangeCurrencyCode(newCurrencyCode);
 
-            //Fallback to default
-            if (config.getExchangeCurrencyCode() == null) {
-                log.info("Using default Country: US");
-                log.info("Using default currency: " + Constants.DEFAULT_EXCHANGE_CURRENCY);
-                config.setExchangeCurrencyCode(Constants.DEFAULT_EXCHANGE_CURRENCY);
+                //Fallback to default
+                if (config.getExchangeCurrencyCode() == null) {
+                    setDefaultExchangeCurrencyCode();
+                }
+            } catch (IllegalArgumentException x) {
+                log.info("Cannot obtain currency for " + countryCode + ": ", x);
+                setDefaultExchangeCurrencyCode();
             }
 
         } else {
-            log.info("Using default Country: US");
-            log.info("Using default currency: " + Constants.DEFAULT_EXCHANGE_CURRENCY);
-            config.setExchangeCurrencyCode(Constants.DEFAULT_EXCHANGE_CURRENCY);
+            setDefaultExchangeCurrencyCode();
         }
+    }
+
+    private void setDefaultExchangeCurrencyCode() {
+        log.info("Using default Country: US");
+        log.info("Using default currency: " + Constants.DEFAULT_EXCHANGE_CURRENCY);
+        config.setExchangeCurrencyCode(Constants.DEFAULT_EXCHANGE_CURRENCY);
     }
 
     private String getCurrentCountry() {
@@ -1171,9 +1178,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
 
         //Fallback to default
         if (config.getExchangeCurrencyCode() == null) {
-            log.info("Using default Country: US");
-            log.info("Using default currency: " + Constants.DEFAULT_EXCHANGE_CURRENCY);
-            config.setExchangeCurrencyCode(Constants.DEFAULT_EXCHANGE_CURRENCY);
+            setDefaultExchangeCurrencyCode();
         }
     }
 


### PR DESCRIPTION
This addresses two crashes that were found when running the Prelaunch Report on Google
1.  Crash from adding a Spork Listener - solution was to remove it since it wasn't be used
2.  Crash from trying to get the Currency on a Locale that was invalid.  Not sure why this would be the case, but the default currency is set to USD in these cases.