### PR TITLE
Fixed build failures on Android Studio 3.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.1'
         classpath('fr.avianey.androidsvgdrawable:gradle-plugin:3.0.0') {
             exclude group: 'xerces'
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4G
-android.enableSeparateAnnotationProcessing=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Oct 15 07:56:54 COT 2018
+#Wed Mar 04 05:59:34 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/ui-redesign/build.gradle
+++ b/ui-redesign/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta2'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta4'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/ui-redesign/src/main/java/org/dash/wallet/ui/widget/LockScreenButton.kt
+++ b/ui-redesign/src/main/java/org/dash/wallet/ui/widget/LockScreenButton.kt
@@ -21,7 +21,7 @@ class LockScreenButton(context: Context, attrs: AttributeSet) : LinearLayout(con
             if (actionIconDrawable != null) {
                 action_icon.setImageDrawable(actionIconDrawable)
             }
-            val actionText = attrsArray.getString(R.styleable.LockScreenButton_text)
+            val actionText = attrsArray.getString(R.styleable.LockScreenButton_label)
             if (actionText != null) {
                 findViewById<TextView>(R.id.action_text).text = actionText
             }

--- a/ui-redesign/src/main/res/values/attrs.xml
+++ b/ui-redesign/src/main/res/values/attrs.xml
@@ -14,7 +14,7 @@
     </declare-styleable>
     <declare-styleable name="LockScreenButton">
         <attr name="action_icon" />
-        <attr name="text" />
+        <attr name="label" format="reference"/>
         <attr name="action_icon_padding" format="dimension" />
     </declare-styleable>
     <declare-styleable name="FingerprintView">

--- a/ui-redesign/src/main/res/values/attrs.xml
+++ b/ui-redesign/src/main/res/values/attrs.xml
@@ -14,7 +14,7 @@
     </declare-styleable>
     <declare-styleable name="LockScreenButton">
         <attr name="action_icon" />
-        <attr name="label" format="reference"/>
+        <attr name="text" format="reference"/>
         <attr name="action_icon_padding" format="dimension" />
     </declare-styleable>
     <declare-styleable name="FingerprintView">

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.google.android:flexbox:1.1.0'
     implementation 'androidx.preference:preference:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta2'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta4'
     implementation "org.dashj:dashj-core:$dashjVersion"
     implementation 'com.google.protobuf:protobuf-java:3.4.0'
     implementation 'com.google.guava:guava:27.0.1-android'

--- a/wallet/res/layout/activity_lock_screen.xml
+++ b/wallet/res/layout/activity_lock_screen.xml
@@ -141,7 +141,7 @@
         app:layout_constraintStart_toStartOf="@id/left_guideline"
         app:layout_constraintWidth_default="percent"
         app:layout_constraintWidth_percent="0.24"
-        app:text="@string/lock_action_quick_receive" />
+        app:label="@string/lock_action_quick_receive" />
 
     <org.dash.wallet.ui.widget.LockScreenButton
         android:id="@+id/action_login_with_pin"
@@ -156,7 +156,7 @@
         app:layout_constraintStart_toStartOf="@id/v_center_guideline"
         app:layout_constraintWidth_default="percent"
         app:layout_constraintWidth_percent="0.24"
-        app:text="@string/lock_action_login_with_pin" />
+        app:label="@string/lock_action_login_with_pin" />
 
     <org.dash.wallet.ui.widget.LockScreenButton
         android:id="@+id/action_login_with_fingerprint"
@@ -171,7 +171,7 @@
         app:layout_constraintStart_toStartOf="@id/v_center_guideline"
         app:layout_constraintWidth_default="percent"
         app:layout_constraintWidth_percent="0.24"
-        app:text="@string/lock_action_login_with_fingerprint" />
+        app:label="@string/lock_action_login_with_fingerprint" />
 
     <org.dash.wallet.ui.widget.LockScreenButton
         android:id="@+id/action_scan_to_pay"
@@ -186,7 +186,7 @@
         app:layout_constraintStart_toStartOf="@id/right_guideline"
         app:layout_constraintWidth_default="percent"
         app:layout_constraintWidth_percent="0.24"
-        app:text="@string/lock_action_scan_to_pay" />
+        app:label="@string/lock_action_scan_to_pay" />
 
     <de.schildbach.wallet.ui.widget.NumericKeyboardView
         android:id="@+id/numeric_keyboard"


### PR DESCRIPTION
Fixes build failures caused by updating Android Studio to version 3.6.1. 
```
ui-redesign\build\intermediates\packaged_res\debug\values\values.xml:79:5-83:25: AAPT: error: resource attr/text not found.
constraintlayout-2.0.0-beta2\res\values\values.xml:268:5-4347: AAPT: error: resource attr/flow_horizontalSeparator not found.
constraintlayout-2.0.0-beta2\res\values\values.xml:268:5-4347: AAPT: error: resource attr/flow_verticalSeparator not found.
constraintlayout-2.0.0-beta2\res\values\values.xml:269:5-3548: AAPT: error: resource attr/flow_horizontalSeparator not found.
constraintlayout-2.0.0-beta2\res\values\values.xml:269:5-3548: AAPT: error: resource attr/flow_verticalSeparator not found.
constraintlayout-2.0.0-beta2\res\values\values.xml:271:5-4382: AAPT: error: resource attr/flow_horizontalSeparator not found.
constraintlayout-2.0.0-beta2\res\values\values.xml:271:5-4382: AAPT: error: resource attr/flow_verticalSeparator not found.
constraintlayout-2.0.0-beta2\res\values\values.xml:271:5-4382: AAPT: error: resource attr/motionProgress not found.
constraintlayout-2.0.0-beta2\res\values\values.xml:274:5-588: AAPT: error: resource attr/motionProgress not found.
constraintlayout-2.0.0-beta2\res\values\values.xml:275:5-652: AAPT: error: resource attr/motionProgress not found.
constraintlayout-2.0.0-beta2\res\values\values.xml:284:5-653: AAPT: error: resource attr/motionProgress not found.
constraintlayout-2.0.0-beta2\res\values\values.xml:284:5-653: AAPT: error: resource attr/waveDecay not found.
constraintlayout-2.0.0-beta2\res\values\values.xml:288:5-232: AAPT: error: resource attr/motionPathRotate not found.
constraintlayout-2.0.0-beta2\res\values\values.xml:290:5-295:36: AAPT: error: resource attr/motionProgress not found.
constraintlayout-2.0.0-beta2\res\values\values.xml:318:5-232: AAPT: error: resource attr/motionProgress not found.
constraintlayout-2.0.0-beta2\res\values\values.xml:322:5-335:98: AAPT: error: resource attr/duration not found.
```

**Update
Turned out the above issue was caused not by updating Android Studio itself but rather by recommended updating Android Gradle plugin to version 3.6.1 and Gradle to version 5.6.4**