### PR TITLE
Avoid app bar resizing when hiding/showing wallet balance [v2]

### DIFF
--- a/wallet/res/layout/header_balance_fragment.xml
+++ b/wallet/res/layout/header_balance_fragment.xml
@@ -7,6 +7,7 @@
     android:paddingStart="14dp"
     android:paddingEnd="14dp"
     android:paddingBottom="32dp">
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -24,83 +25,96 @@
             android:layout_marginTop="?attr/actionBarSize"
             android:text="@string/home_available_balance" />
 
-        <TextView
-            android:id="@+id/wallet_balance_sync_message"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:gravity="center_horizontal"
-            android:text="@string/sync_status_wait"
-            android:textColor="@color/dash_light_gray"
-            android:textSize="16sp"
-            app:fontFamily="@font/montserrat_regular" />
-
         <LinearLayout
-            android:id="@+id/balances_layout"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:background="@drawable/selectable_background_light"
-            android:orientation="vertical"
-            android:padding="8dp">
+            android:orientation="vertical">
 
-            <LinearLayout
-                android:id="@+id/balances"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:gravity="center_vertical|end"
-                android:orientation="horizontal">
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
-                <ImageView
-                    android:layout_width="18dp"
-                    android:layout_height="18dp"
-                    android:layout_marginEnd="4dp"
-                    android:layout_marginRight="4dp"
-                    app:srcCompat="@drawable/ic_dash_d_white"
-                    tools:ignore="ContentDescription" />
-
-                <org.dash.wallet.common.ui.CurrencyTextView
-                    android:id="@+id/wallet_balance_dash"
+                <TextView
+                    android:id="@+id/wallet_balance_sync_message"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:ellipsize="end"
-                    android:maxLength="7"
-                    android:textColor="@color/white"
-                    android:textSize="24sp"
+                    android:layout_gravity="center"
+                    android:gravity="center_horizontal"
+                    android:text="@string/sync_status_wait"
+                    android:textColor="@color/dash_light_gray"
+                    android:textSize="16sp"
                     app:fontFamily="@font/montserrat_regular" />
 
-            </LinearLayout>
+                <LinearLayout
+                    android:id="@+id/balances_layout"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:background="@drawable/selectable_background_light"
+                    android:orientation="vertical"
+                    android:padding="8dp">
 
-            <org.dash.wallet.common.ui.CurrencyTextView
-                android:id="@+id/wallet_balance_local"
+                    <LinearLayout
+                        android:id="@+id/balances"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical|end"
+                        android:orientation="horizontal">
+
+                        <ImageView
+                            android:layout_width="18dp"
+                            android:layout_height="18dp"
+                            android:layout_marginEnd="4dp"
+                            android:layout_marginRight="4dp"
+                            app:srcCompat="@drawable/ic_dash_d_white"
+                            tools:ignore="ContentDescription" />
+
+                        <org.dash.wallet.common.ui.CurrencyTextView
+                            android:id="@+id/wallet_balance_dash"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:ellipsize="end"
+                            android:maxLength="7"
+                            android:textColor="@color/white"
+                            android:textSize="24sp"
+                            app:fontFamily="@font/montserrat_regular" />
+
+                    </LinearLayout>
+
+                    <org.dash.wallet.common.ui.CurrencyTextView
+                        android:id="@+id/wallet_balance_local"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal"
+                        android:textColor="@color/dash_light_gray"
+                        android:textSize="14sp"
+                        app:fontFamily="@font/montserrat_regular"
+                        app:prefixColor="@color/dash_light_gray" />
+
+                </LinearLayout>
+
+                <ImageView
+                    android:id="@+id/show_balance_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|center_horizontal"
+                    android:background="@drawable/transparent_button_background"
+                    android:padding="8dp"
+                    app:srcCompat="@drawable/ic_show_balance" />
+
+            </FrameLayout>
+
+            <TextView
+                android:id="@+id/hide_show_balance_hint"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
+                android:layout_gravity="center"
+                android:layout_marginTop="8dp"
                 android:textColor="@color/dash_light_gray"
-                android:textSize="14sp"
-                app:fontFamily="@font/montserrat_regular"
-                app:prefixColor="@color/dash_light_gray" />
+                android:textSize="@dimen/font_size_tiny" />
 
         </LinearLayout>
 
-        <ImageView
-            android:id="@+id/show_balance_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom|center_horizontal"
-            android:background="@drawable/transparent_button_background"
-            android:padding="8dp"
-            app:srcCompat="@drawable/ic_show_balance" />
-
-
-        <TextView
-            android:id="@+id/hide_show_balance_hint"
-            android:textSize="@dimen/font_size_tiny"
-            android:textColor="@color/dash_light_gray"
-            android:layout_marginTop="8dp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal" />
     </LinearLayout>
 
 </FrameLayout>

--- a/wallet/res/layout/home_content.xml
+++ b/wallet/res/layout/home_content.xml
@@ -35,7 +35,7 @@
                 <fragment
                     android:id="@+id/wallet_balance_fragment"
                     android:name="de.schildbach.wallet.ui.HeaderBalanceFragment"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal"
                     tools:layout="@layout/header_balance_fragment" />

--- a/wallet/src/de/schildbach/wallet/ui/HeaderBalanceFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/HeaderBalanceFragment.java
@@ -176,18 +176,16 @@ public final class HeaderBalanceFragment extends Fragment {
     private void updateView() {
         View balances = view.findViewById(R.id.balances_layout);
         TextView walletBalanceSyncMessage = view.findViewById(R.id.wallet_balance_sync_message);
-        View balancesLayout = view.findViewById(R.id.balances_layout);
 
         if (hideBalance) {
-            balancesLayout.setVisibility(View.GONE);
             caption.setText(R.string.home_balance_hidden);
             hideShowBalanceHint.setText(R.string.home_balance_show_hint);
-            balances.setVisibility(View.GONE);
+            balances.setVisibility(View.INVISIBLE);
             walletBalanceSyncMessage.setVisibility(View.GONE);
             showBalanceButton.setVisibility(View.VISIBLE);
             return;
         }
-        balancesLayout.setVisibility(View.VISIBLE);
+        balances.setVisibility(View.VISIBLE);
         caption.setText(R.string.home_available_balance);
         hideShowBalanceHint.setText(R.string.home_balance_hide_hint);
         showBalanceButton.setVisibility(View.GONE);


### PR DESCRIPTION
This will replace #344 since it was based on a PR that was updated and had many merge conflicts.