### PR TITLE
NMA-434 wallet crashes when send on uphold account and close uphold window

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/InteractionAwareActivity.java
+++ b/common/src/main/java/org/dash/wallet/common/InteractionAwareActivity.java
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-package org.dash.wallet.common
+package org.dash.wallet.common;
 
-import android.annotation.SuppressLint
-import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity;
 
+public class InteractionAwareActivity extends AppCompatActivity {
 
-@SuppressLint("Registered")
-open class InteractionAwareActivity : AppCompatActivity() {
-
-    override fun onUserInteraction() {
-        (application as ResetAutoLogoutTimerHandler).resetAutoLogoutTimer()
+    @Override
+    public void onUserInteraction() {
+        super.onUserInteraction();
+        ((ResetAutoLogoutTimerHandler) getApplication()).resetAutoLogoutTimer();
     }
 }

--- a/common/src/main/java/org/dash/wallet/common/InteractionAwareActivity.kt
+++ b/common/src/main/java/org/dash/wallet/common/InteractionAwareActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Dash Core Group
+ * Copyright 2020 Dash Core Group
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-package de.schildbach.wallet.ui
+package org.dash.wallet.common
 
 import android.annotation.SuppressLint
 import androidx.appcompat.app.AppCompatActivity
-import de.schildbach.wallet.WalletApplication
 
 
 @SuppressLint("Registered")
 open class InteractionAwareActivity : AppCompatActivity() {
 
     override fun onUserInteraction() {
-        (application as WalletApplication).resetAutoLogoutTimer()
+        (application as ResetAutoLogoutTimerHandler).resetAutoLogoutTimer()
     }
 }

--- a/common/src/main/java/org/dash/wallet/common/ResetAutoLogoutTimerHandler.java
+++ b/common/src/main/java/org/dash/wallet/common/ResetAutoLogoutTimerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Dash Core Group
+ * Copyright 2020 Dash Core Group
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,9 @@
  * limitations under the License.
  */
 
-package de.schildbach.wallet.ui
+package org.dash.wallet.common;
 
-import android.annotation.SuppressLint
-import de.schildbach.wallet.WalletApplication
-import org.dash.wallet.common.InteractionAwareActivity
+public interface ResetAutoLogoutTimerHandler {
 
-@SuppressLint("Registered")
-open class ShortcutComponentActivity : InteractionAwareActivity() {
-
-    open fun finishIfNotInitialized(): Boolean {
-        if (WalletApplication.getInstance().wallet == null) {
-            startActivity(OnboardingActivity.createIntent(this))
-            finish()
-            return true
-        }
-        return false
-    }
+    void resetAutoLogoutTimer();
 }

--- a/uphold-integration/src/main/java/org/dash/wallet/integration/uphold/ui/UpholdAccountActivity.java
+++ b/uphold-integration/src/main/java/org/dash/wallet/integration/uphold/ui/UpholdAccountActivity.java
@@ -30,7 +30,6 @@ import android.view.View;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.core.content.ContextCompat;
@@ -38,6 +37,7 @@ import androidx.core.content.ContextCompat;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.utils.MonetaryFormat;
 import org.bitcoinj.wallet.Wallet;
+import org.dash.wallet.common.InteractionAwareActivity;
 import org.dash.wallet.common.customtabs.CustomTabActivityHelper;
 import org.dash.wallet.common.ui.CurrencyTextView;
 import org.dash.wallet.common.ui.DialogBuilder;
@@ -49,7 +49,7 @@ import org.dash.wallet.integration.uphold.data.UpholdException;
 
 import java.math.BigDecimal;
 
-public class UpholdAccountActivity extends AppCompatActivity {
+public class UpholdAccountActivity extends InteractionAwareActivity {
 
     public static final String WALLET_RECEIVING_ADDRESS_EXTRA = "uphold_receiving_address_extra";
 
@@ -159,6 +159,9 @@ public class UpholdAccountActivity extends AppCompatActivity {
         UpholdClient.getInstance().getDashBalance(new UpholdClient.Callback<BigDecimal>() {
             @Override
             public void onSuccess(BigDecimal data) {
+                if (isFinishing()) {
+                    return;
+                }
                 balance = data;
                 balanceView.setAmount(Coin.parseCoin(balance.toString()));
                 loadingDialog.cancel();
@@ -166,6 +169,9 @@ public class UpholdAccountActivity extends AppCompatActivity {
 
             @Override
             public void onError(Exception e, boolean otpRequired) {
+                if (isFinishing()) {
+                    return;
+                }
                 loadingDialog.cancel();
 
                 if(e instanceof UpholdException) {
@@ -236,12 +242,18 @@ public class UpholdAccountActivity extends AppCompatActivity {
                 UpholdClient.getInstance().revokeAccessToken(new UpholdClient.Callback<String>() {
                     @Override
                     public void onSuccess(String result) {
+                        if (isFinishing()) {
+                            return;
+                        }
                         startUpholdSplashActivity();
                         openUpholdToLogout();
                     }
 
                     @Override
                     public void onError(Exception e, boolean otpRequired) {
+                        if (isFinishing()) {
+                            return;
+                        }
                         if(e instanceof UpholdException) {
                             UpholdException ue = (UpholdException)e;
                             showErrorAlert(ue.getCode());

--- a/uphold-integration/src/main/java/org/dash/wallet/integration/uphold/ui/UpholdSplashActivity.java
+++ b/uphold-integration/src/main/java/org/dash/wallet/integration/uphold/ui/UpholdSplashActivity.java
@@ -29,17 +29,17 @@ import androidx.annotation.Nullable;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import android.view.MenuItem;
 import android.view.View;
 
+import org.dash.wallet.common.InteractionAwareActivity;
 import org.dash.wallet.common.customtabs.CustomTabActivityHelper;
 import org.dash.wallet.integration.uphold.R;
 import org.dash.wallet.integration.uphold.data.UpholdClient;
 import org.dash.wallet.integration.uphold.data.UpholdConstants;
 
-public class UpholdSplashActivity extends AppCompatActivity {
+public class UpholdSplashActivity extends InteractionAwareActivity {
 
     public static final String UPHOLD_EXTRA_CODE = "uphold_extra_code";
     public static final String UPHOLD_EXTRA_STATE = "uphold_extra_state";
@@ -106,12 +106,18 @@ public class UpholdSplashActivity extends AppCompatActivity {
             UpholdClient.getInstance().getAccessToken(code, new UpholdClient.Callback<String>() {
                 @Override
                 public void onSuccess(String dashCardId) {
+                    if (isFinishing()) {
+                        return;
+                    }
                     loadingDialog.hide();
                     startUpholdAccountActivity();
                 }
 
                 @Override
                 public void onError(Exception e, boolean otpRequired) {
+                    if (isFinishing()) {
+                        return;
+                    }
                     loadingDialog.hide();
                     showLoadingErrorAlert();
                 }

--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -59,6 +59,7 @@ import org.bitcoinj.wallet.UnreadableWalletException;
 import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.WalletProtobufSerializer;
 import org.dash.wallet.common.Configuration;
+import org.dash.wallet.common.ResetAutoLogoutTimerHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,7 +99,7 @@ import de.schildbach.wallet_test.R;
 /**
  * @author Andreas Schildbach
  */
-public class WalletApplication extends MultiDexApplication {
+public class WalletApplication extends MultiDexApplication implements ResetAutoLogoutTimerHandler {
     private static WalletApplication instance;
     private Configuration config;
     private ActivityManager activityManager;
@@ -271,6 +272,7 @@ public class WalletApplication extends MultiDexApplication {
         autoLogout.setup();
     }
 
+    @Override
     public void resetAutoLogoutTimer() {
         autoLogout.resetTimerIfActive();
     }

--- a/wallet/src/de/schildbach/wallet/ui/BaseMenuActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/BaseMenuActivity.kt
@@ -21,11 +21,11 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.annotation.LayoutRes
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet_test.R
 import org.dash.wallet.common.Configuration
+import org.dash.wallet.common.InteractionAwareActivity
 
 /**
  * @author Samuel Barbosa

--- a/wallet/src/de/schildbach/wallet/ui/GlobalFooterActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/GlobalFooterActivity.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import de.schildbach.wallet.ui.widget.GlobalFooterView
 import de.schildbach.wallet_test.R
+import org.dash.wallet.common.InteractionAwareActivity
 
 
 @SuppressLint("Registered")

--- a/wallet/src/de/schildbach/wallet/ui/ReceiveActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/ReceiveActivity.kt
@@ -9,6 +9,7 @@ import de.schildbach.wallet.ui.receive.ReceiveDetailsDialog
 import de.schildbach.wallet.ui.send.EnterAmountSharedViewModel
 import de.schildbach.wallet_test.R
 import org.bitcoinj.core.Coin
+import org.dash.wallet.common.InteractionAwareActivity
 
 class ReceiveActivity : InteractionAwareActivity() {
 

--- a/wallet/src/de/schildbach/wallet/ui/UpholdTransferActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/UpholdTransferActivity.kt
@@ -34,6 +34,7 @@ import de.schildbach.wallet.ui.send.EnterAmountSharedViewModel
 import de.schildbach.wallet_test.R
 import org.bitcoinj.core.Coin
 import org.bitcoinj.utils.MonetaryFormat
+import org.dash.wallet.common.InteractionAwareActivity
 import org.dash.wallet.common.util.GenericUtils
 import org.dash.wallet.integration.uphold.data.UpholdTransaction
 import org.dash.wallet.integration.uphold.ui.UpholdWithdrawalHelper

--- a/wallet/src/de/schildbach/wallet/ui/VerifySeedActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/VerifySeedActivity.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.ViewModelProviders
 import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet.livedata.Status
 import de.schildbach.wallet_test.R
+import org.dash.wallet.common.InteractionAwareActivity
 
 /**
  * @author Samuel Barbosa


### PR DESCRIPTION
Moved InteractionAwareActivity to 'common' module in order to be able to use it in other submodules (ie uphold-integration).
Fixed crash when manipulating UI elements after finishing Activity (in uphold-integration).
