### PR TITLE
NMA-445  Dash Address in Clipboard not detected in Payment Screen

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/PaymentsActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/PaymentsActivity.kt
@@ -73,8 +73,8 @@ class PaymentsActivity : GlobalFooterActivity() {
 
             override fun onTabSelected(tab: TabLayout.Tab) {
                 initialReselection = false
-                val fragment = when {
-                    tab.position == 0 -> PaymentsPayFragment.newInstance()
+                val fragment = when (tab.position) {
+                    0 -> PaymentsPayFragment.newInstance()
                     else -> PaymentsReceiveFragment.newInstance()
                 }
                 supportFragmentManager.beginTransaction()


### PR DESCRIPTION
Fixed the issue on Android 10 with updating the status of 'Send to copied address' button in Payments/Send screen based on clipboard content.

Additionally, added observing the clipboard content in order to provide instant feedback if content of clipboard has changed.