### PR TITLE
NMA-446 Crash after upgrade - IllegalStateException: Not encrypted

### DIFF
--- a/wallet/res/layout/fragment_enter_pin.xml
+++ b/wallet/res/layout/fragment_enter_pin.xml
@@ -29,6 +29,7 @@
                 android:padding="16dp">
 
                 <TextView
+                    android:id="@+id/title"
                     style="@style/MontserratMedium.PageTitle"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -718,15 +718,15 @@ public class WalletApplication extends MultiDexApplication implements ResetAutoL
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    public void finalizeWipe() {
+    public void shutdownAndDeleteWallet() {
         if (walletFile.exists()) {
             wallet.shutdownAutosaveAndWait();
             walletFile.delete();
         }
-        System.out.println("walletFile.exists(): " + walletFile.exists());
-        if (walletFile.exists()) {
-            walletFile.delete();
-        }
+    }
+
+    public void finalizeWipe() {
+        shutdownAndDeleteWallet();
         cleanupFiles();
         config.clear();
         PinRetryController.getInstance().clearPinFailPrefs();

--- a/wallet/src/de/schildbach/wallet/livedata/EncryptWalletLiveData.kt
+++ b/wallet/src/de/schildbach/wallet/livedata/EncryptWalletLiveData.kt
@@ -46,11 +46,11 @@ class EncryptWalletLiveData(application: Application) : MutableLiveData<Resource
         securityGuard.savePin(pin)
     }
 
-    fun encrypt(scryptIterationsTarget: Int) {
+    fun encrypt(scryptIterationsTarget: Int, initialize: Boolean = true) {
         if (encryptWalletTask == null) {
             this.scryptIterationsTarget = scryptIterationsTarget
             encryptWalletTask = EncryptWalletTask()
-            encryptWalletTask!!.execute()
+            encryptWalletTask!!.execute(initialize)
         }
     }
 
@@ -80,6 +80,7 @@ class EncryptWalletLiveData(application: Application) : MutableLiveData<Resource
         }
 
         override fun doInBackground(vararg args: Any): Resource<Wallet> {
+            val initialize = args[0] as Boolean
             val wallet = walletApplication.wallet
 
             val password = securityGuard.generateRandomPassword()
@@ -91,7 +92,9 @@ class EncryptWalletLiveData(application: Application) : MutableLiveData<Resource
                 val newKey = keyCrypter.deriveKey(password)
                 wallet.encrypt(keyCrypter, newKey)
 
-                walletApplication.saveWalletAndFinalizeInitialization()
+                if(initialize) {
+                    walletApplication.saveWalletAndFinalizeInitialization()
+                }
 
                 securityGuard.savePassword(password)
 

--- a/wallet/src/de/schildbach/wallet/ui/AppUpgradeActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/AppUpgradeActivity.kt
@@ -21,6 +21,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.view.View
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
@@ -61,7 +62,7 @@ class AppUpgradeActivity : AppCompatActivity() {
 
         configuration = WalletApplication.getInstance().configuration
         configuration.pinLength = PinPreviewView.CUSTOM_PIN_LENGTH
-        
+
         pinRetryController = PinRetryController.getInstance()
 
         temporaryLockCheckRunnable.run()
@@ -74,10 +75,17 @@ class AppUpgradeActivity : AppCompatActivity() {
         checkPinSharedModel.onCorrectPinCallback.observe(this, Observer<Pair<Int?, String?>> { (_, pin) ->
             onCorrectPin(pin!!)
         })
+        checkPinSharedModel.onWalletEncryptedCallback.observe(this, Observer<String?> { pin ->
+            if (pin == null) {
+                Toast.makeText(this, "Unable to encrypt wallet", Toast.LENGTH_LONG).show()
+            } else {
+                onCorrectPin(pin)
+            }
+        })
         checkPinSharedModel.onCancelCallback.observe(this, Observer<Void> {
             temporaryLockCheckRunnable.run()
         })
-        CheckPinDuringUpgradeDialog.show(this, 0)
+        SetupPinDuringUpgradeDialog.show(this, 0)
     }
 
     private fun onCorrectPin(pin: String) {

--- a/wallet/src/de/schildbach/wallet/ui/AppUpgradeActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/AppUpgradeActivity.kt
@@ -89,9 +89,6 @@ class AppUpgradeActivity : AppCompatActivity() {
     }
 
     private fun onCorrectPin(pin: String) {
-        val securityGuard = SecurityGuard()
-        securityGuard.savePin(pin)
-        securityGuard.savePassword(pin)
         configuration.pinLength = pin.length
         startActivity(WalletActivity.createIntent(this))
     }

--- a/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
+++ b/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
@@ -83,7 +83,7 @@ open class CheckPinDialog : DialogFragment() {
     protected var fingerprintHelper: FingerprintHelper? = null
     protected lateinit var fingerprintCancellationSignal: CancellationSignal
 
-    private var pinLength = WalletApplication.getInstance().configuration.pinLength
+    protected var pinLength = WalletApplication.getInstance().configuration.pinLength
 
     protected enum class State {
         ENTER_PIN,
@@ -126,7 +126,7 @@ open class CheckPinDialog : DialogFragment() {
                 }
                 if (viewModel.pin.length == pinLength) {
                     Handler().postDelayed({
-                        viewModel.checkPin(viewModel.pin)
+                        checkPin(viewModel.pin.toString())
                     }, 200)
                 }
             }
@@ -152,6 +152,10 @@ open class CheckPinDialog : DialogFragment() {
                 pin_or_fingerprint_button.isEnabled = false
             } else initFingerprint()
         }
+    }
+
+    open fun checkPin(pin: String) {
+        viewModel.checkPin(pin)
     }
 
     /*

--- a/wallet/src/de/schildbach/wallet/ui/CheckPinSharedModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/CheckPinSharedModel.kt
@@ -25,4 +25,5 @@ open class CheckPinSharedModel : ViewModel() {
 
     val onCancelCallback = SingleLiveEventExt<Void>()
 
+    val onWalletEncryptedCallback = SingleLiveEventExt<String?>()
 }

--- a/wallet/src/de/schildbach/wallet/ui/OnboardingActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/OnboardingActivity.kt
@@ -29,7 +29,6 @@ import android.widget.LinearLayout
 import android.widget.Toast
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
-import com.jakewharton.processphoenix.ProcessPhoenix
 import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet.ui.preference.PinRetryController
 import de.schildbach.wallet.ui.security.SecurityGuard
@@ -106,13 +105,7 @@ class OnboardingActivity : RestoreFromFileActivity() {
         if (SecurityGuard.isConfiguredQuickCheck()) {
             startMainActivity()
         } else {
-            if (walletApplication.wallet.isEncrypted) {
-                startActivity(AppUpgradeActivity.createIntent(this))
-            } else {
-                // this can happen if the wallet was created in old version and PIN wasn't set
-                walletApplication.shutdownAndDeleteWallet();
-                ProcessPhoenix.triggerRebirth(this)
-            }
+            startActivity(AppUpgradeActivity.createIntent(this))
         }
     }
 

--- a/wallet/src/de/schildbach/wallet/ui/OnboardingActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/OnboardingActivity.kt
@@ -29,6 +29,7 @@ import android.widget.LinearLayout
 import android.widget.Toast
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
+import com.jakewharton.processphoenix.ProcessPhoenix
 import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet.ui.preference.PinRetryController
 import de.schildbach.wallet.ui.security.SecurityGuard
@@ -85,7 +86,7 @@ class OnboardingActivity : RestoreFromFileActivity() {
                     walletApplication.fullInitialization()
                     regularFlow()
                 } else {
-                    startActivity(SetPinActivity.createIntent(this, R.string.set_pin_create_new_wallet))
+                    onboarding()
                 }
             }
         }
@@ -105,7 +106,13 @@ class OnboardingActivity : RestoreFromFileActivity() {
         if (SecurityGuard.isConfiguredQuickCheck()) {
             startMainActivity()
         } else {
-            startActivity(AppUpgradeActivity.createIntent(this))
+            if (walletApplication.wallet.isEncrypted) {
+                startActivity(AppUpgradeActivity.createIntent(this))
+            } else {
+                // this can happen if the wallet was created in old version and PIN wasn't set
+                walletApplication.shutdownAndDeleteWallet();
+                ProcessPhoenix.triggerRebirth(this)
+            }
         }
     }
 

--- a/wallet/src/de/schildbach/wallet/ui/SetPinViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SetPinViewModel.kt
@@ -47,13 +47,17 @@ class SetPinViewModel(application: Application) : AndroidViewModel(application) 
 
     fun savePinAndEncrypt() {
         val pin = getPinAsString()
-        encryptWalletLiveData.savePin(pin)
-        encryptWallet()
+        savePinAndEncrypt(pin, true)
     }
 
-    private fun encryptWallet() {
+    fun savePinAndEncrypt(pin: String, initialize: Boolean) {
+        encryptWalletLiveData.savePin(pin)
+        encryptWallet(initialize)
+    }
+
+    private fun encryptWallet(initialize: Boolean) {
         if (!walletApplication.wallet.isEncrypted) {
-            encryptWalletLiveData.encrypt(walletApplication.scryptIterationsTarget())
+            encryptWalletLiveData.encrypt(walletApplication.scryptIterationsTarget(), initialize)
         } else {
             log.warn("Trying to encrypt already encrypted wallet")
         }


### PR DESCRIPTION
Fixed 'IllegalStateException: Not encrypted' crash:

```
2020-03-19 14:27:38.419 11201-11321/hashengineering.darkcoin.wallet_test E/AndroidRuntime: FATAL EXCEPTION: backgroundThread
Process: hashengineering.darkcoin.wallet_test, PID: 11201
java.lang.IllegalStateException: Not encrypted
at com.google.common.base.Preconditions.checkState(Preconditions.java:511)
at org.bitcoinj.wallet.KeyChainGroup.checkPassword(KeyChainGroup.java:468)
at org.bitcoinj.wallet.Wallet.checkPassword(Wallet.java:1399)
at de.schildbach.wallet.ui.CheckWalletPasswordTask$1.run(CheckWalletPasswordTask.java:40)
at android.os.Handler.handleCallback(Handler.java:883)
at android.os.Handler.dispatchMessage(Handler.java:100)
at android.os.Looper.loop(Looper.java:214)
at android.os.HandlerThread.run(HandlerThread.java:67)
```

If the old version (before 7.0.0) was installed and the PIN wasn't set by the user
the wallet file isn't encrypted, which causes crash when trying to check the PIN after upgrade.
This PR cause that the user is asked to set up a new PIN in such a case.