### PR TITLE
NMA-440 Fix Local Currency: Invalid Currency Crash

### DIFF
--- a/wallet/src/de/schildbach/wallet/rates/ExchangeRate.java
+++ b/wallet/src/de/schildbach/wallet/rates/ExchangeRate.java
@@ -59,13 +59,7 @@ public class ExchangeRate {
 
     private Currency getCurrency() {
         if (currency == null) {
-            try {
-                currency = Currency.getInstance(currencyCode.toUpperCase());
-            } catch (IllegalArgumentException x) {
-                // if the device doesn't have the currency code it is list of
-                // ISO 4217 codes, then return the code as the name
-                return currency;
-            }
+            currency = Currency.getInstance(currencyCode.toUpperCase());
         }
         return currency;
     }
@@ -79,9 +73,16 @@ public class ExchangeRate {
         if (currencyName == null) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
                 // currency codes must be 3 letters before calling getCurrency()
-                if(currencyCode.length() == 3)
-                    currencyName = getCurrency().getDisplayName();
-                else currencyName = currencyCode;
+                // If the currency is not a valid ISO 4217 code, then set the
+                // currency name to be equal to the currency code
+                // exchanges often have "invalid" currency codes like USDT and CNH
+                if(currencyCode.length() == 3) {
+                    try {
+                        currencyName = getCurrency().getDisplayName();
+                    } catch (IllegalArgumentException x) {
+                        currencyName = currencyCode;
+                    }
+                } else currencyName = currencyCode;
 
                 if(currencyCode.toUpperCase().equals(currencyName.toUpperCase())) {
                     currencyName = CurrencyInfo.getOtherCurrencyName(currencyCode);

--- a/wallet/src/de/schildbach/wallet/rates/ExchangeRate.java
+++ b/wallet/src/de/schildbach/wallet/rates/ExchangeRate.java
@@ -59,7 +59,13 @@ public class ExchangeRate {
 
     private Currency getCurrency() {
         if (currency == null) {
-            currency = Currency.getInstance(currencyCode.toUpperCase());
+            try {
+                currency = Currency.getInstance(currencyCode.toUpperCase());
+            } catch (IllegalArgumentException x) {
+                // if the device doesn't have the currency code it is list of
+                // ISO 4217 codes, then return the code as the name
+                return currency;
+            }
         }
         return currency;
     }


### PR DESCRIPTION
This should resolve the exceptions seen on Chinese devices with android 6 and 7.

```
 FATAL EXCEPTION: ControllerMessenger
Process: hashengineering.darkcoin.wallet, PID: 1206
java.lang.IllegalArgumentException: Unsupported ISO 4217 currency code: CNH
	at java.util.Currency.<init>(Currency.java:40)
	at java.util.Currency.getInstance(Currency.java:54)
	at de.schildbach.wallet.rates.ExchangeRate.getCurrency(ExchangeRate.java:62)
	at de.schildbach.wallet.rates.ExchangeRate.getCurrencyName(ExchangeRate.java:77)
	at de.schildbach.wallet.ui.ExchangeRatesFragment$ExchangeRatesAdapter.onBindViewHolder(ExchangeRatesFragment.java:370)
	at de.schildbach.wallet.ui.ExchangeRatesFragment$ExchangeRatesAdapter.onBindViewHolder(ExchangeRatesFragment.java:286)
	at androidx.recyclerview.widget.RecyclerView$Adapter.onBindViewHolder(RecyclerView.java:7033)
```
	