### PR TITLE
NMA-453 Fix for Notification / Network Monitor do not update during sync process

### DIFF
--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -170,6 +170,7 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
     public static final String START_AS_FOREGROUND_EXTRA = "start_as_foreground";
 
     private Executor executor = Executors.newSingleThreadExecutor();
+    private int syncPercentage = 0; // 0 to 100%
 
     private final ThrottlingWalletChangeListener walletEventListener = new ThrottlingWalletChangeListener(
             APPWIDGET_THROTTLE_MS) {
@@ -377,19 +378,32 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
                     if(timeAgo < DateUtils.DAY_IN_MILLIS)
                         config.setRestoringBackup(false);
                 }
+                // this method is always called after progress or doneDownload
+                updateBlockchainState();
             }
         };
 
+        /*
+            This method is called by super.onBlocksDownloaded when the percentage
+            of the chain downloaded is 0.0, 1.0, 2.0, 3.0 .. 99.0% (whole numbers)
+
+            The pct value is relative to the blocks that need to be downloaded to sync,
+            rather than the relative to the entire blockchain.
+         */
         @Override
         protected void progress(double pct, int blocksLeft, Date date) {
             super.progress(pct, blocksLeft, date);
-            updateBlockchainState();
+            syncPercentage = pct > 0.0 ? (int)pct : 0;
         }
 
+        /*
+            This method is called by super.onBlocksDownloaded when the percentage
+            of the chain downloaded is 100.0% (completely done)
+        */
         @Override
         protected void doneDownload() {
             super.doneDownload();
-            updateBlockchainState();
+            syncPercentage = 100;
         }
     };
 
@@ -1026,6 +1040,11 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
     }
 
     private void handleBlockchainStateNotification(BlockchainState blockchainState) {
+        // send this out for the Network Monitor, other activities observe the database
+        final Intent broadcast = new Intent(ACTION_BLOCKCHAIN_STATE);
+        broadcast.setPackage(getPackageName());
+        LocalBroadcastManager.getInstance(this).sendBroadcast(broadcast);
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && blockchainState != null
                 && blockchainState.getBestChainDate() != null) {
             //Handle Ongoing notification state
@@ -1045,19 +1064,7 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
     }
 
     private int percentageSync() {
-        int chainHeadHeight = blockChain.getChainHead().getHeight();
-        int mostCommonChainHeight;
-        if (peerGroup == null) {
-            return 0;
-        }
-        if (peerGroup.getMostCommonChainHeight() > 0) {
-            mostCommonChainHeight = peerGroup.getMostCommonChainHeight();
-        } else {
-            mostCommonChainHeight = chainHeadHeight;
-        }
-        float percentage = ((float) chainHeadHeight / (float) mostCommonChainHeight) * 100;
-        log.info("mostCommonChainHeight: " + mostCommonChainHeight + "\tchainHeadHeight: " + chainHeadHeight + "\t" + percentage + "%\t" + config.getBestChainHeightEver());
-        return (int) percentage;
+        return syncPercentage;
     }
 
     private void updateAppWidget() {


### PR DESCRIPTION
- Replace sync percentage calculation (use relative progress rather than absolute)

- broadcast `ACTION_BLOCKCHAIN_STATE `for Network Monitor (no other activity listens for this since https://github.com/dashevo/dash-wallet/commit/10f34a67a47de59c7e0d69a33fb8b2858aa3c07f, #339).  The network monitor needs to know when the blockchain tip has changed so it can display that last 50+ transactions.  It does not need the blockchain state itself (at least not until information about chainlocks needs to be displayed).

- Update blockchain state more regularly, possibly.  This may help the sync notification close more often.  The assumption is made that the `progress `and `doneDownload ` methods may not always trigger the blockchain state to be updated and the notification stays on for a longer period of time.  This is only a guess, but returns some behavior to the v6 app, which did work for having the notification close when the app was done syncing.