### PR TITLE
NMA-471 Lock Screen Fingerprint Crash on Android 6

### DIFF
--- a/wallet/src/de/schildbach/wallet/util/FingerprintHelper.java
+++ b/wallet/src/de/schildbach/wallet/util/FingerprintHelper.java
@@ -99,6 +99,11 @@ public class FingerprintHelper {
         KeyguardManager keyguardManager = (KeyguardManager) context.getSystemService(KEYGUARD_SERVICE);
         fingerprintManager = FingerprintManagerCompat.from(context);
 
+        if (!fingerprintManager.isHardwareDetected()) {
+            log.info("Fingerprint hardware not detected");
+            return  false;
+        }
+
         if (!keyguardManager.isKeyguardSecure()) {
             log.info("User hasn't enabled Lock Screen");
             return false;


### PR DESCRIPTION
Detecting the fingerprint hardware (isHardwareDetected()) before calling hasEnrolledFingerprints() in order to avoid SecurityException. As suggested here: https://stackoverflow.com/questions/37780080/android-fingerprints-hasenrolledfingerprints-triggers-exception-on-some-samsung