### PR TITLE
NMA-469 Uphold Related Crashes

### DIFF
--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -48,6 +48,7 @@ import com.google.common.base.Stopwatch;
 import com.jakewharton.processphoenix.ProcessPhoenix;
 
 import org.bitcoinj.core.CoinDefinition;
+import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.core.VersionMessage;
@@ -60,6 +61,7 @@ import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.WalletProtobufSerializer;
 import org.dash.wallet.common.Configuration;
 import org.dash.wallet.common.ResetAutoLogoutTimerHandler;
+import org.dash.wallet.integration.uphold.data.UpholdClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -266,6 +268,16 @@ public class WalletApplication extends MultiDexApplication implements ResetAutoL
                 }
             }
         });
+        initUphold();
+    }
+
+    private void initUphold() {
+        //Uses Sha256 hash of excerpt of xpub as Uphold authentication salt
+        String xpub = wallet.getWatchingKey().serializePubB58(Constants.NETWORK_PARAMETERS);
+        byte[] xpubExcerptHash = Sha256Hash.hash(xpub.substring(4, 15).getBytes());
+        String authenticationHash = Sha256Hash.wrap(xpubExcerptHash).toString();
+
+        UpholdClient.init(getApplicationContext(), authenticationHash);
     }
 
     public void maybeStartAutoLogoutTimer() {

--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -162,7 +162,6 @@ public final class WalletActivity extends AbstractBindServiceActivity
 
         MaybeMaintenanceFragment.add(getSupportFragmentManager());
 
-        initUphold();
         initView();
 
         //Prevent showing dialog twice or more when activity is recreated (e.g: rotating device, etc)
@@ -207,15 +206,6 @@ public final class WalletActivity extends AbstractBindServiceActivity
                 fingerprintHelper = null;
             }
         }
-    }
-
-    private void initUphold() {
-        //Uses Sha256 hash of excerpt of xpub as Uphold authentication salt
-        String xpub = wallet.getWatchingKey().serializePubB58(Constants.NETWORK_PARAMETERS);
-        byte[] xpubExcerptHash = Sha256Hash.hash(xpub.substring(4, 15).getBytes());
-        String authenticationHash = Sha256Hash.wrap(xpubExcerptHash).toString();
-
-        UpholdClient.init(getApplicationContext(), authenticationHash);
     }
 
     private void initView() {


### PR DESCRIPTION
Fixed:
```
Caused by: java.lang.IllegalStateException: 
  at org.dash.wallet.integration.uphold.data.UpholdClient.getInstance (UpholdClient.java:128)
  at org.dash.wallet.integration.uphold.ui.UpholdAccountActivity.loadUserBalance (UpholdAccountActivity.java:159)
  at org.dash.wallet.integration.uphold.ui.UpholdAccountActivity.onResume (UpholdAccountActivity.java:143)
  at android.app.Instrumentation.callActivityOnResume (Instrumentation.java:1413)
  at android.app.Activity.performResume (Activity.java:7408)
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:3858)
```
The UpholdClient was initialized in WalletActivity, which was causing the lack of initialization if the UpholdAccountActivity was oppened first.