### PR TITLE
NMA-448 Fix InstantSend/Chainlocks crashes by Updating to dashj 0.17.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    dashjVersion = "0.17"
+    dashjVersion = "0.17.1"
 }
 
 buildscript {

--- a/wallet/cpp/dashj-bls/dashj-bls-signature-wrapper.cpp
+++ b/wallet/cpp/dashj-bls/dashj-bls-signature-wrapper.cpp
@@ -690,7 +690,7 @@ SWIGEXPORT void JNICALL Java_org_dashj_bls_JNI_BLS_1SetContextError(JNIEnv *jenv
   core_get()->code = error;
 }
 
-std::string DASHJ_VERSION = "0.17";
+std::string DASHJ_VERSION = "0.17.1";
 
 SWIGEXPORT jstring JNICALL Java_org_dashj_bls_JNI_BLS_1GetVersionString(JNIEnv *jenv, jclass jcls) {
   (void)jenv;


### PR DESCRIPTION
This resolves some crashes when processing instantsend and chainlocks.

Another fix to dashj was to remove the infinite loop when the send transaction fails (added for 0.14 nodes, which are not common anymore on the network).