### PR TITLE
NMA-480  Lock Screen Crash: Set Backup Reminder

### DIFF
--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -157,7 +157,7 @@ public class WalletApplication extends MultiDexApplication implements ResetAutoL
             @Override
             protected void onStartedFirst(Activity activity) {
                 autoLogout.setAppInBackground(false);
-                if (config.getAutoLogoutEnabled() && (deviceWasLocked || autoLogout.shouldLogout())) {
+                if (wallet != null && config.getAutoLogoutEnabled() && (deviceWasLocked || autoLogout.shouldLogout())) {
                     lockTheApp(WalletApplication.this, activity);
                     if (autoLogout.isTimerActive()) {
                         autoLogout.stopTimer();


### PR DESCRIPTION
Prevent Auto Logout functionality from trying to lock the app before wallet is initialized