### PR TITLE
NMA-473 Payment Request from another app gets stuck on Transaction Result Screen

### DIFF
--- a/wallet/AndroidManifest.xml
+++ b/wallet/AndroidManifest.xml
@@ -60,7 +60,8 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:largeHeap="true"
-        android:theme="@style/My.Theme">
+        android:theme="@style/My.Theme"
+        tools:ignore="LockedOrientationActivity">
 
         <activity
             android:name="de.schildbach.wallet.ui.OnboardingActivity"
@@ -109,8 +110,13 @@
         </activity-alias>
 
         <activity
+            android:name="de.schildbach.wallet.ui.send.SendCoinsInternalActivity"
+            android:label="@string/pay_title"
+            android:screenOrientation="portrait"
+            android:theme="@style/My.Theme.ChildActivity" />
+
+        <activity
             android:name="de.schildbach.wallet.ui.send.SendCoinsActivity"
-            android:configChanges="keyboard|keyboardHidden"
             android:label="@string/pay_title"
             android:screenOrientation="portrait"
             android:theme="@style/My.Theme.ChildActivity"

--- a/wallet/src/de/schildbach/wallet/ui/PaymentsPayFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/PaymentsPayFragment.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Dash Core Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package de.schildbach.wallet.ui
 
 import android.app.Activity
@@ -14,7 +30,7 @@ import android.view.ViewTreeObserver
 import androidx.fragment.app.Fragment
 import de.schildbach.wallet.data.PaymentIntent
 import de.schildbach.wallet.ui.scan.ScanActivity
-import de.schildbach.wallet.ui.send.SendCoinsActivity
+import de.schildbach.wallet.ui.send.SendCoinsInternalActivity
 import de.schildbach.wallet_test.R
 import kotlinx.android.synthetic.main.fragment_payments_pay.*
 import org.bitcoinj.core.PrefixedChecksummedBytes
@@ -115,7 +131,7 @@ class PaymentsPayFragment : Fragment() {
 
             override fun handlePaymentIntent(paymentIntent: PaymentIntent) {
                 if (fireAction) {
-                    SendCoinsActivity.start(context, paymentIntent, true)
+                    SendCoinsInternalActivity.start(context, paymentIntent, true)
                 } else {
                     manageStateOfPayToAddressButton(paymentIntent)
                 }

--- a/wallet/src/de/schildbach/wallet/ui/SendCoinsQrActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/SendCoinsQrActivity.java
@@ -33,7 +33,7 @@ import de.schildbach.wallet.WalletApplication;
 import de.schildbach.wallet.data.PaymentIntent;
 import de.schildbach.wallet.ui.InputParser.StringInputParser;
 import de.schildbach.wallet.ui.scan.ScanActivity;
-import de.schildbach.wallet.ui.send.SendCoinsActivity;
+import de.schildbach.wallet.ui.send.SendCoinsInternalActivity;
 import de.schildbach.wallet.ui.send.SweepWalletActivity;
 
 /**
@@ -80,7 +80,7 @@ public class SendCoinsQrActivity extends ShortcutComponentActivity {
             new StringInputParser(input, true) {
                 @Override
                 protected void handlePaymentIntent(final PaymentIntent paymentIntent) {
-                    SendCoinsActivity.start(SendCoinsQrActivity.this, paymentIntent, false);
+                    SendCoinsInternalActivity.start(SendCoinsQrActivity.this, paymentIntent, false);
 
                     if (isQuickScan()) {
                         SendCoinsQrActivity.this.finish();

--- a/wallet/src/de/schildbach/wallet/ui/SendCoinsQrActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/SendCoinsQrActivity.java
@@ -80,7 +80,7 @@ public class SendCoinsQrActivity extends ShortcutComponentActivity {
             new StringInputParser(input, true) {
                 @Override
                 protected void handlePaymentIntent(final PaymentIntent paymentIntent) {
-                    SendCoinsInternalActivity.start(SendCoinsQrActivity.this, paymentIntent, false);
+                    SendCoinsInternalActivity.start(SendCoinsQrActivity.this, getIntent().getAction(), paymentIntent, false);
 
                     if (isQuickScan()) {
                         SendCoinsQrActivity.this.finish();

--- a/wallet/src/de/schildbach/wallet/ui/SendingAddressesFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/SendingAddressesFragment.java
@@ -38,7 +38,7 @@ import de.schildbach.wallet.data.AddressBookProvider;
 import de.schildbach.wallet.data.PaymentIntent;
 import de.schildbach.wallet.ui.InputParser.StringInputParser;
 import de.schildbach.wallet.ui.scan.ScanActivity;
-import de.schildbach.wallet.ui.send.SendCoinsActivity;
+import de.schildbach.wallet.ui.send.SendCoinsInternalActivity;
 import de.schildbach.wallet.util.BitmapFragment;
 import de.schildbach.wallet.util.Qr;
 import de.schildbach.wallet.util.Toast;
@@ -318,7 +318,7 @@ public final class SendingAddressesFragment extends FancyListFragment
     }
 
     private void handleSend(final String address) {
-        SendCoinsActivity.start(activity, PaymentIntent.fromAddress(address, null));
+        SendCoinsInternalActivity.start(activity, PaymentIntent.fromAddress(address, null));
     }
 
     private void handleRemove(final String address) {

--- a/wallet/src/de/schildbach/wallet/ui/TransactionResultActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/TransactionResultActivity.kt
@@ -46,19 +46,25 @@ class TransactionResultActivity : AbstractWalletActivity() {
         private const val EXTRA_PAYEE_VERIFIED_BY = "payee_verified_by"
 
         @JvmStatic
-        fun createIntent(context: Context, transaction: Transaction, userAuthorized: Boolean): Intent {
-            return createIntent(context, transaction, userAuthorized, null, null)
+        fun createIntent(context: Context, action: String? = null, transaction: Transaction, userAuthorized: Boolean): Intent {
+            return createIntent(context, action, transaction, userAuthorized, null, null)
         }
 
         @JvmStatic
-        fun createIntent(context: Context, transaction: Transaction, userAuthorized: Boolean,
+        fun createIntent(context: Context, transaction: Transaction, userAuthorized: Boolean, payeeName: String? = null,
+                         payeeVerifiedBy: String? = null): Intent {
+            return createIntent(context, null, transaction, userAuthorized, payeeName, payeeVerifiedBy)
+        }
+
+        fun createIntent(context: Context, action: String?, transaction: Transaction, userAuthorized: Boolean,
                          payeeName: String? = null, payeeVerifiedBy: String? = null): Intent {
-            val transactionResultIntent = Intent(context, TransactionResultActivity::class.java)
-            transactionResultIntent.putExtra(EXTRA_TX_ID, transaction.txId)
-            transactionResultIntent.putExtra(EXTRA_USER_AUTHORIZED_RESULT_EXTRA, userAuthorized)
-            transactionResultIntent.putExtra(EXTRA_PAYEE_NAME, payeeName)
-            transactionResultIntent.putExtra(EXTRA_PAYEE_VERIFIED_BY, payeeVerifiedBy)
-            return transactionResultIntent
+            return Intent(context, TransactionResultActivity::class.java).apply {
+                setAction(action)
+                putExtra(EXTRA_TX_ID, transaction.txId)
+                putExtra(EXTRA_USER_AUTHORIZED_RESULT_EXTRA, userAuthorized)
+                putExtra(EXTRA_PAYEE_NAME, payeeName)
+                putExtra(EXTRA_PAYEE_VERIFIED_BY, payeeVerifiedBy)
+            }
         }
     }
 
@@ -77,10 +83,16 @@ class TransactionResultActivity : AbstractWalletActivity() {
             transactionResultViewBinder.bind(tx, payeeName, payeeVerifiedBy)
             view_on_explorer.setOnClickListener { viewOnExplorer(tx) }
             transaction_close_btn.setOnClickListener {
-                if (intent.getBooleanExtra(EXTRA_USER_AUTHORIZED_RESULT_EXTRA, false)) {
-                    startActivity(WalletActivity.createIntent(this))
-                } else {
-                    startActivity(LockScreenActivity.createIntentAsNewTask(this))
+                when {
+                    intent.action == Intent.ACTION_VIEW -> {
+                        finish()
+                    }
+                    intent.getBooleanExtra(EXTRA_USER_AUTHORIZED_RESULT_EXTRA, false) -> {
+                        startActivity(WalletActivity.createIntent(this))
+                    }
+                    else -> {
+                        startActivity(LockScreenActivity.createIntentAsNewTask(this))
+                    }
                 }
             }
         } else {

--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -1,18 +1,17 @@
 /*
- * Copyright 2011-2015 the original author or authors.
+ * Copyright 2020 Dash Core Group
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package de.schildbach.wallet.ui;
@@ -86,7 +85,7 @@ import de.schildbach.wallet.ui.InputParser.BinaryInputParser;
 import de.schildbach.wallet.ui.InputParser.StringInputParser;
 import de.schildbach.wallet.ui.preference.PreferenceActivity;
 import de.schildbach.wallet.ui.scan.ScanActivity;
-import de.schildbach.wallet.ui.send.SendCoinsActivity;
+import de.schildbach.wallet.ui.send.SendCoinsInternalActivity;
 import de.schildbach.wallet.ui.send.SweepWalletActivity;
 import de.schildbach.wallet.ui.widget.UpgradeWalletDisclaimerDialog;
 import de.schildbach.wallet.util.CrashReporter;
@@ -366,7 +365,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
         new StringInputParser(input, true) {
             @Override
             protected void handlePaymentIntent(final PaymentIntent paymentIntent) {
-                SendCoinsActivity.start(WalletActivity.this, paymentIntent, true);
+                SendCoinsInternalActivity.start(WalletActivity.this, paymentIntent, true);
             }
 
             @Override
@@ -468,7 +467,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
     }
 
     public void handleSendCoins() {
-        SendCoinsActivity.start(this, null, true);
+        SendCoinsInternalActivity.start(this, null, true);
     }
 
     public void handleScan(View clickView) {

--- a/wallet/src/de/schildbach/wallet/ui/WalletUriHandlerActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletUriHandlerActivity.java
@@ -35,7 +35,7 @@ import de.schildbach.wallet.Constants;
 import de.schildbach.wallet.WalletApplication;
 import de.schildbach.wallet.data.PaymentIntent;
 import de.schildbach.wallet.integration.android.BitcoinIntegration;
-import de.schildbach.wallet.ui.send.SendCoinsActivity;
+import de.schildbach.wallet.ui.send.SendCoinsInternalActivity;
 import de.schildbach.wallet_test.R;
 
 /**
@@ -95,7 +95,7 @@ public final class WalletUriHandlerActivity extends AppCompatActivity {
                 new InputParser.WalletUriParser(intentUri) {
                     @Override
                     protected void handlePaymentIntent(final PaymentIntent paymentIntent, boolean forceInstantSend) {
-                        SendCoinsActivity.sendFromWalletUri(
+                        SendCoinsInternalActivity.sendFromWalletUri(
                                 WalletUriHandlerActivity.this, REQUEST_CODE_SEND_FROM_WALLET_URI, paymentIntent);
                     }
 

--- a/wallet/src/de/schildbach/wallet/ui/send/PaymentProtocolFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/send/PaymentProtocolFragment.kt
@@ -252,10 +252,12 @@ class PaymentProtocolFragment : Fragment() {
     private fun showTransactionResult(transaction: Transaction) {
         val payeeName = paymentProtocolModel.finalPaymentIntent!!.payeeName
         val payeeVerifiedBy = paymentProtocolModel.finalPaymentIntent!!.payeeVerifiedBy
-        val transactionResultIntent = TransactionResultActivity.createIntent(
-                activity!!, transaction, isUserAuthorized(), payeeName, payeeVerifiedBy)
-        startActivity(transactionResultIntent)
-        activity!!.finish()
+        activity!!.run {
+            val transactionResultIntent = TransactionResultActivity.createIntent(
+                    this, intent.action, transaction, isUserAuthorized(), payeeName, payeeVerifiedBy)
+            startActivity(transactionResultIntent)
+            finish()
+        }
     }
 
     private fun handleSendRequestException() {

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsActivity.java
@@ -1,6 +1,4 @@
 /*
- * Copyright 2011-2015 the original author or authors.
-/*
  * Copyright 2020 Dash Core Group
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,8 +16,6 @@
 
 package de.schildbach.wallet.ui.send;
 
-import android.app.Activity;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
@@ -45,37 +41,11 @@ import de.schildbach.wallet.ui.AbstractBindServiceActivity;
 import de.schildbach.wallet.util.Nfc;
 import de.schildbach.wallet_test.R;
 
-/**
- * @author Andreas Schildbach
- */
-public final class SendCoinsActivity extends AbstractBindServiceActivity {
+public class SendCoinsActivity extends AbstractBindServiceActivity {
 
     public static final List<String> ANYPAY_SCHEMES = Arrays.asList("pay");
 
     public static final String INTENT_EXTRA_PAYMENT_INTENT = "payment_intent";
-    public static final String INTENT_EXTRA_USER_AUTHORIZED = "user_authorized";
-
-    public static final String ACTION_SEND_FROM_WALLET_URI = "de.schildbach.wallet.action.SEND_FROM_WALLET_URI";
-
-    public static void start(final Context context, final PaymentIntent paymentIntent) {
-        start(context, paymentIntent, false);
-    }
-
-    public static void start(final Context context, final PaymentIntent paymentIntent, boolean userAuthorized) {
-        final Intent intent = new Intent(context, SendCoinsActivity.class);
-        intent.putExtra(INTENT_EXTRA_PAYMENT_INTENT, paymentIntent);
-        intent.putExtra(INTENT_EXTRA_USER_AUTHORIZED, userAuthorized);
-        context.startActivity(intent);
-    }
-
-    public static void sendFromWalletUri(final Activity callingActivity, int requestCode,
-                                         final PaymentIntent paymentIntent) {
-        final Intent intent = new Intent(callingActivity, SendCoinsActivity.class);
-        intent.setAction(ACTION_SEND_FROM_WALLET_URI);
-        intent.putExtra(INTENT_EXTRA_USER_AUTHORIZED, false);
-        intent.putExtra(INTENT_EXTRA_PAYMENT_INTENT, paymentIntent);
-        callingActivity.startActivityForResult(intent, requestCode);
-    }
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
@@ -186,22 +156,14 @@ public final class SendCoinsActivity extends AbstractBindServiceActivity {
     };
 
     public boolean isUserAuthorized() {
-        String action = getIntent().getAction();
-        if (Intent.ACTION_VIEW.equals(action)) {
-            return false;
-        }
-        if (NfcAdapter.ACTION_NDEF_DISCOVERED.equals(action)) {
-            return false;
-        }
-        return getIntent().getBooleanExtra(INTENT_EXTRA_USER_AUTHORIZED, false);
+        return false;
     }
 
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                finish();
-                return true;
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
         }
 
         return super.onOptionsItemSelected(item);

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
@@ -102,7 +102,7 @@ public class SendCoinsFragment extends Fragment {
         return activity.isUserAuthorized() || userAuthorizedDuring;
     }
 
-    final DialogInterface.OnClickListener activityDismissListener = new DialogInterface.OnClickListener() {
+    private final DialogInterface.OnClickListener activityDismissListener = new DialogInterface.OnClickListener() {
         @Override
         public void onClick(final DialogInterface dialog, final int which) {
             activity.finish();
@@ -414,7 +414,7 @@ public class SendCoinsFragment extends Fragment {
         }
 
         Intent transactionResultIntent = TransactionResultActivity.createIntent(activity,
-                transaction, activity.isUserAuthorized());
+                activity.getIntent().getAction(), transaction, activity.isUserAuthorized());
         startActivity(transactionResultIntent);
     }
 

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsInternalActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsInternalActivity.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Dash Core Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.schildbach.wallet.ui.send;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.nfc.NfcAdapter;
+
+import de.schildbach.wallet.data.PaymentIntent;
+
+public class SendCoinsInternalActivity extends SendCoinsActivity {
+
+    public static final String INTENT_EXTRA_USER_AUTHORIZED = "user_authorized";
+
+    public static final String ACTION_SEND_FROM_WALLET_URI = "de.schildbach.wallet.action.SEND_FROM_WALLET_URI";
+
+    public static void start(final Context context, final PaymentIntent paymentIntent) {
+        start(context, paymentIntent, false);
+    }
+
+    public static void start(final Context context, final PaymentIntent paymentIntent, boolean userAuthorized) {
+        final Intent intent = new Intent(context, SendCoinsInternalActivity.class);
+        intent.putExtra(INTENT_EXTRA_PAYMENT_INTENT, paymentIntent);
+        intent.putExtra(INTENT_EXTRA_USER_AUTHORIZED, userAuthorized);
+        context.startActivity(intent);
+    }
+
+    public static void sendFromWalletUri(final Activity callingActivity, int requestCode,
+                                         final PaymentIntent paymentIntent) {
+        final Intent intent = new Intent(callingActivity, SendCoinsInternalActivity.class);
+        intent.setAction(ACTION_SEND_FROM_WALLET_URI);
+        intent.putExtra(INTENT_EXTRA_USER_AUTHORIZED, false);
+        intent.putExtra(INTENT_EXTRA_PAYMENT_INTENT, paymentIntent);
+        callingActivity.startActivityForResult(intent, requestCode);
+    }
+
+    public boolean isUserAuthorized() {
+        String action = getIntent().getAction();
+        if (Intent.ACTION_VIEW.equals(action)) {
+            return false;
+        }
+        if (NfcAdapter.ACTION_NDEF_DISCOVERED.equals(action)) {
+            return false;
+        }
+        return getIntent().getBooleanExtra(INTENT_EXTRA_USER_AUTHORIZED, false);
+    }
+    
+}

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsInternalActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsInternalActivity.java
@@ -34,7 +34,14 @@ public class SendCoinsInternalActivity extends SendCoinsActivity {
     }
 
     public static void start(final Context context, final PaymentIntent paymentIntent, boolean userAuthorized) {
+        start(context, null, paymentIntent, userAuthorized);
+    }
+
+    public static void start(final Context context, final String action, final PaymentIntent paymentIntent, boolean userAuthorized) {
         final Intent intent = new Intent(context, SendCoinsInternalActivity.class);
+        if (action != null) {
+            intent.setAction(action);
+        }
         intent.putExtra(INTENT_EXTRA_PAYMENT_INTENT, paymentIntent);
         intent.putExtra(INTENT_EXTRA_USER_AUTHORIZED, userAuthorized);
         context.startActivity(intent);
@@ -59,5 +66,5 @@ public class SendCoinsInternalActivity extends SendCoinsActivity {
         }
         return getIntent().getBooleanExtra(INTENT_EXTRA_USER_AUTHORIZED, false);
     }
-    
+
 }

--- a/wallet/src/de/schildbach/wallet/ui/send/SweepWalletFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SweepWalletFragment.java
@@ -636,7 +636,7 @@ public class SweepWalletFragment extends Fragment {
 		}
 
 		Intent transactionResultIntent = TransactionResultActivity.createIntent(activity,
-				sentTransaction, activity.isUserAuthorized());
+				null, sentTransaction, activity.isUserAuthorized());
 		startActivity(transactionResultIntent);
 		activity.finish();
 	}


### PR DESCRIPTION
Added SendCoinsInternalActivity being not exported version of SendCoinsActivity extended with ability to be authorised internally.
Closing the app if it was launched by external Intent.