### PR TITLE
NMA-485 Attempt to resolve RemoteServiceExceptions on Oreo

### DIFF
--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -705,6 +705,7 @@ public class WalletApplication extends MultiDexApplication implements ResetAutoL
 
         Intent serviceIntent = new Intent(context, BlockchainServiceImpl.class);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            serviceIntent.putExtra(BlockchainServiceImpl.START_AS_FOREGROUND_EXTRA, true);
             alarmIntent = PendingIntent.getForegroundService(context, 0, serviceIntent,
                     PendingIntent.FLAG_UPDATE_CURRENT);
         } else {

--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -705,7 +705,6 @@ public class WalletApplication extends MultiDexApplication implements ResetAutoL
 
         Intent serviceIntent = new Intent(context, BlockchainServiceImpl.class);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            serviceIntent.putExtra(BlockchainServiceImpl.START_AS_FOREGROUND_EXTRA, true);
             alarmIntent = PendingIntent.getForegroundService(context, 0, serviceIntent,
                     PendingIntent.FLAG_UPDATE_CURRENT);
         } else {

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -166,6 +166,8 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
 
     private static final Logger log = LoggerFactory.getLogger(BlockchainServiceImpl.class);
 
+    public static final String START_AS_FOREGROUND_EXTRA = "start_as_foreground";
+
     private Executor executor = Executors.newSingleThreadExecutor();
     private int syncPercentage = 0; // 0 to 100%
 
@@ -787,6 +789,12 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
         super.onStartCommand(intent, flags, startId);
 
         if (intent != null) {
+            //Restart service as a Foreground Service if it's synchronizing the blockchain
+            Bundle extras = intent.getExtras();
+            if (extras != null && extras.containsKey(START_AS_FOREGROUND_EXTRA)) {
+                startForeground();
+            }
+
             log.info("service start command: " + intent + (intent.hasExtra(Intent.EXTRA_ALARM_COUNT)
                     ? " (alarm count: " + intent.getIntExtra(Intent.EXTRA_ALARM_COUNT, 0) + ")" : ""));
 

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -166,8 +166,6 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
 
     private static final Logger log = LoggerFactory.getLogger(BlockchainServiceImpl.class);
 
-    public static final String START_AS_FOREGROUND_EXTRA = "start_as_foreground";
-
     private Executor executor = Executors.newSingleThreadExecutor();
     private int syncPercentage = 0; // 0 to 100%
 
@@ -689,6 +687,10 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
         final PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
         wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, lockName);
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForeground();
+        }
+
         application = (WalletApplication) getApplication();
         config = application.getConfiguration();
         final Wallet wallet = application.getWallet();
@@ -785,12 +787,6 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
         super.onStartCommand(intent, flags, startId);
 
         if (intent != null) {
-            //Restart service as a Foreground Service if it's synchronizing the blockchain
-            Bundle extras = intent.getExtras();
-            if (extras != null && extras.containsKey(START_AS_FOREGROUND_EXTRA)) {
-                startForeground();
-            }
-
             log.info("service start command: " + intent + (intent.hasExtra(Intent.EXTRA_ALARM_COUNT)
                     ? " (alarm count: " + intent.getIntExtra(Intent.EXTRA_ALARM_COUNT, 0) + ")" : ""));
 


### PR DESCRIPTION
Always promote the `BlockchainServiceImpl` service to the foreground to avoid RemoteServiceException on Android 8 when `onCreate` takes too long.

An interesting discussin about this issue: https://stackoverflow.com/questions/44425584/context-startforegroundservice-did-not-then-call-service-startforeground
it seems that to completely get rid of this issue we will have to replace the AlarmManager based solution with the JobScheduler-based.

For now let's just see if this codes change anything.