### PR TITLE
[NMA-526]: Transaction Details Crashes on Android 4.4

### DIFF
--- a/wallet/res/layout/nav_header_main.xml
+++ b/wallet/res/layout/nav_header_main.xml
@@ -11,7 +11,7 @@
     android:paddingBottom="12dp">
 
     <fragment
-        android:id="@+id/wallet_address_fragment"
+        android:id="@+id/address_fragment"
         android:name="de.schildbach.wallet.ui.WalletAddressFragment"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -33,9 +33,9 @@
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
         android:scaleType="centerInside"
-        android:layout_toLeftOf="@id/wallet_address_fragment"
-        android:layout_toStartOf="@id/wallet_address_fragment"
-        android:layout_alignBottom="@id/wallet_address_fragment"
+        android:layout_toLeftOf="@id/address_fragment"
+        android:layout_toStartOf="@id/address_fragment"
+        android:layout_alignBottom="@id/address_fragment"
         app:srcCompat="@drawable/dash_logo_white"/>
 
 </RelativeLayout>

--- a/wallet/res/layout/transaction_result_content.xml
+++ b/wallet/res/layout/transaction_result_content.xml
@@ -331,7 +331,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
             android:layout_marginBottom="4dp"
-            android:drawableStart="@drawable/ic_secured_by"
+            app:drawableStartCompat="@drawable/ic_secured_by"
             android:drawablePadding="4dp"
             android:text="@string/dialog_confirm_secured_by"
             android:textColor="@color/dash_gray" />

--- a/wallet/res/layout/view_payment_request_details.xml
+++ b/wallet/res/layout/view_payment_request_details.xml
@@ -116,7 +116,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
             android:layout_marginBottom="4dp"
-            android:drawableStart="@drawable/ic_secured_by"
+            app:drawableStartCompat="@drawable/ic_secured_by"
             android:drawablePadding="4dp"
             android:text="@string/dialog_confirm_secured_by"
             android:textColor="@color/dash_gray" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Crash on KitKat when displaying the transaction details or BIP70 transaction details.

## What was done?
<!--- Describe your changes in detail -->
Replaced `android:drawableStart` with `app:drawableStartCompat` in two `TextViews`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Displayed the transaction details screen and performed BIP70 payment on KitKat.
QA validation.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone