### PR TITLE
Fix issue with automatic deploy of evonet-develop branch

### DIFF
--- a/.deploy/deploy.sh
+++ b/.deploy/deploy.sh
@@ -7,7 +7,7 @@ if [ "${DEPLOY_TYPE}" = "master" ] || [ "${DEPLOY_TYPE}" = "DashPay" ] || [ "${T
   cd "$TRAVIS_BUILD_DIR" || exit
 
   if [ "${DEPLOY_TYPE}" = "master" ] || [ "${DEPLOY_TYPE}" = "DashPay" ]; then
-    TRAVIS_TAG=DEPLOY_TYPE
+    TRAVIS_TAG=$DEPLOY_TYPE
   fi
 
   eval "$(ssh-agent -s)" # Start ssh-agent cache


### PR DESCRIPTION
Added missing $ prefix when assigning variable causing the deploy directory to be named `DEPLOY_TYPE` instead of DashPay/master