### PR TITLE
Another attempt to fix the KRIP crash on Android 8.0/8.1

### DIFF
--- a/wallet/AndroidManifest.xml
+++ b/wallet/AndroidManifest.xml
@@ -339,6 +339,9 @@
         <service
             android:name="de.schildbach.wallet.service.InactivityNotificationService"
             android:exported="false" />
+        <service
+            android:name="de.schildbach.wallet.service.BlockchainSyncJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
 
         <meta-data
             android:name="android.nfc.disable_beam_default"

--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -709,14 +709,19 @@ public class WalletApplication extends MultiDexApplication implements ResetAutoL
 
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.O || Build.VERSION.SDK_INT == Build.VERSION_CODES.O_MR1) {
             log.info("custom sync scheduling with JobScheduler for Android 8 and 8.1");
-            ComponentName jobService = new ComponentName(context, BlockchainSyncJobService.class);
-            JobInfo jobInfo = new JobInfo.Builder(BLOCKCHAIN_SYNC_JOB_ID, jobService)
-                    .setPeriodic(alarmInterval)
-                    .setPersisted(true)
-                    .build();
             JobScheduler jobScheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
-            int scheduleResult = jobScheduler.schedule(jobInfo);
-            log.info("job scheduling result: {}", scheduleResult);
+            JobInfo pendingJob = jobScheduler.getPendingJob(BLOCKCHAIN_SYNC_JOB_ID);
+            if(pendingJob == null || pendingJob.getIntervalMillis() != alarmInterval) {
+                ComponentName jobService = new ComponentName(context, BlockchainSyncJobService.class);
+                JobInfo jobInfo = new JobInfo.Builder(BLOCKCHAIN_SYNC_JOB_ID, jobService)
+                        .setPeriodic(alarmInterval)
+                        .setPersisted(true)
+                        .build();
+                int scheduleResult = jobScheduler.schedule(jobInfo);
+                log.info("scheduling blockchain sync job with interval of {}s, result: {}", alarmInterval/1000, scheduleResult);
+            } else {
+                log.info("blockchain sync job already scheduled with interval of {}s", alarmInterval / 1000);
+            }
 
         } else {
 

--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -703,6 +703,8 @@ public class WalletApplication extends MultiDexApplication implements ResetAutoL
         else
             alarmInterval = AlarmManager.INTERVAL_DAY;
 
+        final long alarmIntervalMinutes = TimeUnit.MILLISECONDS.toMinutes(alarmInterval);
+
         log.info("last used {} minutes ago, rescheduling blockchain sync in roughly {} minutes",
                 lastUsedAgo / DateUtils.MINUTE_IN_MILLIS, alarmInterval / DateUtils.MINUTE_IN_MILLIS);
 
@@ -731,9 +733,9 @@ public class WalletApplication extends MultiDexApplication implements ResetAutoL
                         .setPersisted(true)
                         .build();
                 int scheduleResult = jobScheduler.schedule(jobInfo);
-                log.info("scheduling blockchain sync job with interval of {}s, result: {}", alarmInterval / 1000, scheduleResult);
+                log.info("scheduling blockchain sync job with interval of {} minutes, result: {}", alarmIntervalMinutes, scheduleResult);
             } else {
-                log.info("blockchain sync job already scheduled with interval of {}s", alarmInterval / 1000);
+                log.info("blockchain sync job already scheduled with interval of {} minutes", alarmIntervalMinutes);
             }
         } else {
             // workaround for no inexact set() before KitKat

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -41,6 +41,7 @@ import android.os.PowerManager.WakeLock;
 import android.text.format.DateUtils;
 
 import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
 import androidx.lifecycle.LifecycleService;
 import androidx.lifecycle.Observer;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -652,7 +653,7 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
     };
 
     public class LocalBinder extends Binder {
-        public BlockchainService getService() {
+        public BlockchainServiceImpl getService() {
             return BlockchainServiceImpl.this;
         }
     }
@@ -1070,5 +1071,14 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
 
     private void updateAppWidget() {
         WalletBalanceWidgetProvider.updateWidgets(BlockchainServiceImpl.this, application.getWallet());
+    }
+
+    public void forceForeground() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Intent intent = new Intent(this, BlockchainServiceImpl.class);
+            ContextCompat.startForegroundService(this, intent);
+            // call startForeground just after startForegroundService.
+            startForeground();
+        }
     }
 }

--- a/wallet/src/de/schildbach/wallet/service/BlockchainSyncJobService.kt
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainSyncJobService.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.schildbach.wallet.service
+
+import android.app.job.JobParameters
+import android.app.job.JobService
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Handler
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import de.schildbach.wallet.WalletApplication
+import org.slf4j.LoggerFactory
+
+@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+class BlockchainSyncJobService : JobService() {
+
+    private val log = LoggerFactory.getLogger(BlockchainSyncJobService::class.java)
+
+    private val serviceIntent: Intent
+    private val context: Context
+
+    init {
+        context = WalletApplication.getInstance()
+        serviceIntent = Intent(context, BlockchainServiceImpl::class.java)
+        serviceIntent.putExtra(BlockchainServiceImpl.START_AS_FOREGROUND_EXTRA, true)
+    }
+
+    override fun onStartJob(params: JobParameters): Boolean {
+        log.info("blockchain sync job started")
+        ContextCompat.startForegroundService(context, serviceIntent)
+        //wait some time just to make sure that the service started
+        Handler().postDelayed({ jobFinished(params, false) }, 3000)
+        return true
+    }
+
+    override fun onStopJob(params: JobParameters): Boolean {
+        log.info("blockchain sync job cancelled before completion")
+        context.stopService(serviceIntent)
+        return false
+    }
+}


### PR DESCRIPTION
Using JobScheduler instead of AlarmManager to trigger periodic blockchain sync on Android 8.0 and 8.1
