### PR TITLE
DashPay: Notification Screen Crash Fix

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/dashpay/NotificationsLiveData.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/NotificationsLiveData.kt
@@ -5,9 +5,9 @@ import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet.data.NotificationItem
 import de.schildbach.wallet.data.UsernameSortOrderBy
 import de.schildbach.wallet.livedata.Resource
+import de.schildbach.wallet.livedata.Status
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import org.bitcoinj.evolution.EvolutionContact
 
 open class NotificationsLiveData(protected val walletApplication: WalletApplication, protected val platformRepo: PlatformRepo) : LiveData<Resource<List<NotificationItem>>>(), OnContactsUpdated {
     private var listening = false
@@ -48,14 +48,17 @@ open class NotificationsLiveData(protected val walletApplication: WalletApplicat
 
             //TODO: gather other notification types
             // * invitations
-            // * payments
+            // * payments are not included
             // * other
 
-            contactRequests.data!!.forEach {
-                results.add(NotificationItem(it))
-            }
+            if (contactRequests.status == Status.SUCCESS) {
 
-            postValue(Resource.success(results))
+                contactRequests.data!!.forEach {
+                    results.add(NotificationItem(it))
+                }
+
+                postValue(Resource.success(results))
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
Fix a crash if the user restores a recovery phrase then immediately goes to the notification screen once the it is possible and before the local database is updated by the background processes.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->
None
## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->
None
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code and added comments where necessary
- [X] I have added or updated relevant unit/integration/functional/e2e tests
