### PR TITLE
Add back button to Passphrase Screen (NMA-456)

### DIFF
--- a/wallet/res/anim/slide_out_right.xml
+++ b/wallet/res/anim/slide_out_right.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:interpolator/decelerate_quad" >
+
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromXDelta="0%"
+        android:toXDelta="100%" />
+
+    <alpha
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromAlpha="1.0"
+        android:toAlpha="100" />
+
+</set>

--- a/wallet/src/de/schildbach/wallet/ui/VerifySeedBaseFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/VerifySeedBaseFragment.kt
@@ -1,0 +1,22 @@
+package de.schildbach.wallet.ui
+
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.Fragment
+import de.schildbach.wallet_test.R
+
+open class VerifySeedBaseFragment protected constructor() : Fragment() {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+        val parentActivity = activity as AppCompatActivity
+        parentActivity.setSupportActionBar(toolbar)
+        parentActivity.supportActionBar?.apply {
+            setDisplayHomeAsUpEnabled(true)
+            setDisplayShowHomeEnabled(true)
+        }
+    }
+}

--- a/wallet/src/de/schildbach/wallet/ui/VerifySeedConfirmFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/VerifySeedConfirmFragment.kt
@@ -26,14 +26,13 @@ import android.view.animation.AnimationUtils
 import android.widget.Button
 import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
-import androidx.fragment.app.Fragment
 import de.schildbach.wallet_test.R
 import kotlinx.android.synthetic.main.verify_seed_verify.*
 
 /**
  * @author Samuel Barbosa
  */
-class VerifySeedConfirmFragment : Fragment() {
+class VerifySeedConfirmFragment : VerifySeedBaseFragment() {
 
     private val shakeAnimation by lazy { AnimationUtils.loadAnimation(context, R.anim.shake) }
     private val wordButtonsContainer by lazy { word_buttons_container }

--- a/wallet/src/de/schildbach/wallet/ui/VerifySeedItIsImportantFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/VerifySeedItIsImportantFragment.kt
@@ -22,13 +22,12 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import androidx.appcompat.widget.Toolbar
-import androidx.fragment.app.Fragment
 import de.schildbach.wallet_test.R
 
 /**
  * @author Samuel Barbosa
  */
-class VerifySeedItIsImportantFragment : Fragment() {
+class VerifySeedItIsImportantFragment : VerifySeedBaseFragment() {
 
     private val showRecoveryPhraseBtn: Button by lazy {
         view!!.findViewById<Button>(R.id.verify_show_recovery_phrase_button)

--- a/wallet/src/de/schildbach/wallet/ui/VerifySeedSecureNowFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/VerifySeedSecureNowFragment.kt
@@ -21,13 +21,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import androidx.fragment.app.Fragment
 import de.schildbach.wallet_test.R
 
 /**
  * @author Samuel Barbosa
  */
-class VerifySeedSecureNowFragment : Fragment() {
+class VerifySeedSecureNowFragment : VerifySeedBaseFragment() {
 
     private val secureNowBtn: Button by lazy { view!!.findViewById<Button>(R.id.verify_secure_now_button) }
     private val skipBtn: Button by lazy { view!!.findViewById<Button>(R.id.verify_skip_button) }

--- a/wallet/src/de/schildbach/wallet/ui/VerifySeedWriteDownFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/VerifySeedWriteDownFragment.kt
@@ -21,14 +21,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.widget.Toolbar
-import androidx.fragment.app.Fragment
 import de.schildbach.wallet_test.R
 import kotlinx.android.synthetic.main.verify_seed_write_down.*
 
 /**
  * @author Samuel Barbosa
  */
-class VerifySeedWriteDownFragment private constructor() : Fragment() {
+class VerifySeedWriteDownFragment private constructor() : VerifySeedBaseFragment() {
 
     private val recoverySeedTextView by lazy { recovery_seed }
     private val confirmCheckBox by lazy { written_down_checkbox }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

Add the back button to the VerifySeed related screens, with animation that is the opposite of going forward in the screens.


## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->
None
## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->
![Screenshot_1597099666](https://user-images.githubusercontent.com/5956129/89838746-e4a9ef80-db20-11ea-8d50-1d4416eb203c.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
