### PR TITLE
Fixing link formatting typo: [text](URL)

### DIFF
--- a/wallet/README.md
+++ b/wallet/README.md
@@ -191,7 +191,7 @@ Instructions for preparing an NFC tag with your address:
 
 ### DASHJ
 
-Dash Wallet uses dashj for Dash specific logic.  This project is forked from [bitcoinj] https://bitcoinj.github.io/
+Dash Wallet uses dashj for Dash specific logic.  This project is forked from [bitcoinj](https://bitcoinj.github.io/)
 
 
 ### EXCHANGE RATES


### PR DESCRIPTION
"This project is forked from [bitcoinj] https://bitcoinj.github.io/" - now bitcoinj will appear as a link, I think that was the original intention.