### PR TITLE
Avoid NavBar overlapping the keyboard on emulator and possibly some devices.

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/LockScreenActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/LockScreenActivity.kt
@@ -22,7 +22,10 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
+import android.view.KeyCharacterMap
+import android.view.KeyEvent
 import android.view.View
+import android.view.ViewConfiguration
 import android.view.animation.AnimationUtils
 import androidx.annotation.RequiresApi
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -120,8 +123,18 @@ class LockScreenActivity : SendCoinsQrActivity() {
     }
 
     private fun hasNavBar(): Boolean {
+        if (Build.FINGERPRINT.startsWith("generic")) {  // emulator
+            return true
+        }
         val id: Int = resources.getIdentifier("config_showNavigationBar", "bool", "android")
-        return id > 0 && resources.getBoolean(id)
+        return if (id > 0) {
+            id > 0 && resources.getBoolean(id)
+        } else {
+            // Check for keys
+            val hasMenuKey = ViewConfiguration.get(this).hasPermanentMenuKey();
+            val hasBackKey = KeyCharacterMap.deviceHasKey(KeyEvent.KEYCODE_BACK);
+            !hasMenuKey && !hasBackKey;
+        }
     }
 
     override fun onStart() {

--- a/wallet/src/de/schildbach/wallet/ui/LockScreenActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/LockScreenActivity.kt
@@ -22,6 +22,7 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
+import android.telephony.TelephonyManager
 import android.view.KeyCharacterMap
 import android.view.KeyEvent
 import android.view.View
@@ -123,7 +124,9 @@ class LockScreenActivity : SendCoinsQrActivity() {
     }
 
     private fun hasNavBar(): Boolean {
-        if (Build.FINGERPRINT.startsWith("generic")) {  // emulator
+        val tm: TelephonyManager = getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+        // emulator
+        if ("Android" == tm.networkOperatorName || Build.FINGERPRINT.startsWith("generic")) {
             return true
         }
         val id: Int = resources.getIdentifier("config_showNavigationBar", "bool", "android")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->
Added additional checks to the LockScreenActivity.hasNavBar() method in order to avoid NavBar overlapping the keyboard on emulator and some devices.
## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

![image](https://user-images.githubusercontent.com/8437401/91154803-3f674d80-e6c2-11ea-8dad-6493df41e585.png)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
