### PR TITLE
Change order that is used to connect to peers (DNM, seeds, dns seeders)

### DIFF
--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -155,7 +155,7 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
     private final SeedPeers seedPeerDiscovery = new SeedPeers(Constants.NETWORK_PARAMETERS);
     private final DnsDiscovery dnsDiscovery = new DnsDiscovery(Constants.DNS_SEED, Constants.NETWORK_PARAMETERS);
     ArrayList<PeerDiscovery> peerDiscoveryList = new ArrayList<>(2);
-
+    private final static int MINIMUM_PEER_COUNT = 16;
 
     private static final int MIN_COLLECT_HISTORY = 2;
     private static final int IDLE_BLOCK_TIMEOUT_MIN = 2;
@@ -528,7 +528,7 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
                                 log.info("DMN List peer discovery failed: "+ x.getMessage());
                             }
 
-                            if(peers.size() < 16) {
+                            if(peers.size() < MINIMUM_PEER_COUNT) {
                                 if (Constants.NETWORK_PARAMETERS.getAddrSeeds() != null) {
                                     log.info("DNM peer discovery returned less than 16 nodes.  Adding seed peers to the list to increase connections");
                                     peers.addAll(Arrays.asList(seedPeerDiscovery.getPeers(services, timeoutValue, timeoutUnit)));
@@ -537,7 +537,7 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
                                 }
                             }
 
-                            if(peers.size() < 16) {
+                            if(peers.size() < MINIMUM_PEER_COUNT) {
                                 log.info("Masternode peer discovery returned less than 16 nodes.  Adding DMN peers to the list to increase connections");
 
                                 try {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->
Original order: DNS Seeders, DMN Masternode List, Hard coded Seeds which are Masternodes

New Order:  DMN Masternode List, Hard coded Seeds which are Masternodes, DNS Seeders (will only be used if the previous two return less than 16 total nodes)

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->
None
## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->
None
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [x] I have added or updated relevant unit/integration/functional/e2e tests
