### PR TITLE
Fixed the crash when taking picture on KitKat

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/Configuration.java
+++ b/common/src/main/java/org/dash/wallet/common/Configuration.java
@@ -78,7 +78,6 @@ public class Configuration {
     public static final String PREFS_V7_REDESIGN_TUTORIAL_COMPLETED = "v7_tutorial_completed";
     public static final String PREFS_PIN_LENGTH = "pin_length";
     public static final String PREFS_LAST_SEEN_NOTIFICATION_TIME = "last_seen_notification_time";
-    public static final String PREFS_KEY_LOCAL_PROFILE_PICTURE_URI = "local_profile_picture_uri";
 
     private static final int PREFS_DEFAULT_BTC_SHIFT = 0;
     private static final int PREFS_DEFAULT_BTC_PRECISION = 8;
@@ -434,13 +433,5 @@ public class Configuration {
 
     public void setLastSeenNotificationTime(long lastSeenNotificationTime) {
         prefs.edit().putLong(PREFS_LAST_SEEN_NOTIFICATION_TIME, lastSeenNotificationTime).apply();
-    }
-
-    public void setLocalProfilePictureUri(String picturePath) {
-        prefs.edit().putString(PREFS_KEY_LOCAL_PROFILE_PICTURE_URI, picturePath).apply();
-    }
-
-    public String getLocalProfilePictureUri() {
-        return prefs.getString(PREFS_KEY_LOCAL_PROFILE_PICTURE_URI, "");
     }
 }

--- a/wallet/res/xml/file_provider.xml
+++ b/wallet/res/xml/file_provider.xml
@@ -13,4 +13,8 @@
         name="ext-download"
         path="Download/" />
 
+    <external-files-path
+        name="app-images"
+        path="Pictures/" />
+
 </paths>

--- a/wallet/src/de/schildbach/wallet/Constants.java
+++ b/wallet/src/de/schildbach/wallet/Constants.java
@@ -189,6 +189,8 @@ public final class Constants {
 
         /** Filename of the file containing Electrum servers. */
         public static final String ELECTRUM_SERVERS_FILENAME = "electrum-servers.txt";
+
+        public static final String PROFILE_PICTURE_FILENAME = "profileimage.jpg";
     }
 
     /** Maximum size of backups. Files larger will be rejected. */

--- a/wallet/src/de/schildbach/wallet/ui/EditProfileActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/EditProfileActivity.kt
@@ -17,13 +17,13 @@
 package de.schildbach.wallet.ui
 
 import android.Manifest
+import android.content.ClipData
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.database.Cursor
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
 import android.text.Editable
@@ -32,6 +32,7 @@ import android.view.View
 import android.widget.Toast
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.bumptech.glide.Glide
@@ -46,8 +47,7 @@ import de.schildbach.wallet_test.R
 import kotlinx.android.synthetic.main.activity_edit_profile.*
 import kotlinx.android.synthetic.main.activity_more.dashpayUserAvatar
 import kotlinx.android.synthetic.main.activity_more.userInfoContainer
-import java.io.FileOutputStream
-import java.io.IOException
+import java.io.File
 
 
 class EditProfileActivity : BaseMenuActivity() {
@@ -58,6 +58,7 @@ class EditProfileActivity : BaseMenuActivity() {
         const val REQUEST_CODE_CHOOSE_PICTURE_PERMISSION = 2
         const val REQUEST_CODE_TAKE_PICTURE_PERMISSION = 3
     }
+
     private lateinit var editProfileViewModel: EditProfileViewModel
     private lateinit var selectProfilePictureSharedViewModel: SelectProfilePictureSharedViewModel
     private var isEditing: Boolean = false
@@ -191,6 +192,10 @@ class EditProfileActivity : BaseMenuActivity() {
         selectProfilePictureSharedViewModel.onChoosePictureCallback.observe(this, Observer<Void> {
             choosePictureWithPermission()
         })
+
+        editProfileViewModel.onTmpPictureReadyForEditEvent.observe(this, Observer {
+            cropProfilePicture()
+        })
     }
 
     private fun showProfileInfo() {
@@ -201,7 +206,11 @@ class EditProfileActivity : BaseMenuActivity() {
             Glide.with(dashpayUserAvatar).load(profile.avatarUrl).circleCrop()
                     .placeholder(defaultAvatar).into(dashpayUserAvatar)
         } else {
-            dashpayUserAvatar.setImageDrawable(defaultAvatar)
+            if (editProfileViewModel.profilePictureFile != null && editProfileViewModel.profilePictureFile!!.exists()) {
+                dashpayUserAvatar.setImageURI(gerFileUri(editProfileViewModel.profilePictureFile!!))
+            } else {
+                dashpayUserAvatar.setImageDrawable(defaultAvatar)
+            }
         }
 
         about_me.setText(profile.publicMessage)
@@ -234,25 +243,47 @@ class EditProfileActivity : BaseMenuActivity() {
     }
 
     private fun choosePicture() {
-        val pickPhoto = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
-        startActivityForResult(pickPhoto, REQUEST_CODE_URI)
+        if (editProfileViewModel.createTmpPictureFile()) {
+            val pickPhoto = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
+            startActivityForResult(pickPhoto, REQUEST_CODE_URI)
+        } else {
+            Toast.makeText(this, "Unable to create temporary file", Toast.LENGTH_LONG).show()
+        }
     }
 
     private fun takePicture() {
-        val takePicture = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
-        startActivityForResult(takePicture, REQUEST_CODE_IMAGE)
+        if (editProfileViewModel.createTmpPictureFile()) {
+            dispatchTakePictureIntent()
+        } else {
+            Toast.makeText(this, "Unable to create temporary file", Toast.LENGTH_LONG).show()
+        }
+    }
+
+    private fun dispatchTakePictureIntent() {
+        Intent(MediaStore.ACTION_IMAGE_CAPTURE).also { takePictureIntent ->
+            // Ensure that there's a camera activity to handle the intent
+            takePictureIntent.resolveActivity(packageManager)?.also {
+                val tmpFileUri = gerFileUri(editProfileViewModel.tmpPictureFile)
+                takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, tmpFileUri)
+                if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP) {
+                    // to avoid 'SecurityException: Permission Denial' on KitKat
+                    takePictureIntent.clipData = ClipData.newRawUri("", tmpFileUri)
+                    takePictureIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+                startActivityForResult(takePictureIntent, REQUEST_CODE_IMAGE)
+            }
+        }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (resultCode != RESULT_CANCELED) {
             when (requestCode) {
-                REQUEST_CODE_IMAGE -> if (resultCode == RESULT_OK && data != null) {
-                    val selectedImage: Bitmap = data.extras["data"] as Bitmap
-                    // TODO: this line is for debugging - show the selected image on the screen
-                    dashpayUserAvatar.setImageBitmap(selectedImage)
-                    editProfileViewModel.saveBitmap(selectedImage)
-                    // TODO: crop the image?
+                REQUEST_CODE_IMAGE -> {
+                    if (resultCode == RESULT_OK) {
+                        // picture saved in editProfileViewModel.profilePictureTmpFile
+                        editProfileViewModel.onTmpPictureReadyForEditEvent.call(editProfileViewModel.tmpPictureFile)
+                    }
                 }
                 REQUEST_CODE_URI -> if (resultCode == RESULT_OK && data != null) {
                     val selectedImage: Uri? = data.data
@@ -264,16 +295,22 @@ class EditProfileActivity : BaseMenuActivity() {
                             cursor.moveToFirst()
                             val columnIndex: Int = cursor.getColumnIndex(filePathColumn[0])
                             val picturePath: String = cursor.getString(columnIndex)
-                            // TODO: this line is for debugging - show the selected image on the screen
-                            dashpayUserAvatar.setImageBitmap(BitmapFactory.decodeFile(picturePath))
-                            editProfileViewModel.localProfileImageUri = picturePath
+                            editProfileViewModel.saveAsProfilePictureTmp(picturePath)
                             cursor.close()
-                            // TODO: crop the image?
                         }
                     }
                 }
             }
         }
+    }
+
+    private fun cropProfilePicture() {
+        val tmpPictureFile = editProfileViewModel.tmpPictureFile
+//        TODO: this line is for debugging - show the selected image on the screen
+//        dashpayUserAvatar.setImageBitmap(BitmapFactory.decodeFile(tmpPictureFile.absolutePath))
+//        or
+        dashpayUserAvatar.setImageURI(gerFileUri(tmpPictureFile))
+        editProfileViewModel.saveTmpAsProfilePicture()
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
@@ -292,5 +329,9 @@ class EditProfileActivity : BaseMenuActivity() {
             }
             else -> super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         }
+    }
+
+    private fun gerFileUri(file: File): Uri {
+        return FileProvider.getUriForFile(walletApplication, "${walletApplication.packageName}.file_attachment", file)
     }
 }

--- a/wallet/src/de/schildbach/wallet/ui/dashpay/EditProfileViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/EditProfileViewModel.kt
@@ -16,23 +16,56 @@
 package de.schildbach.wallet.ui.dashpay
 
 import android.app.Application
-import android.graphics.Bitmap
+import android.os.Environment
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.viewModelScope
 import de.schildbach.wallet.AppDatabase
+import de.schildbach.wallet.Constants
 import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet.data.BlockchainIdentityData
 import de.schildbach.wallet.data.DashPayProfile
+import de.schildbach.wallet.ui.SingleLiveEvent
 import de.schildbach.wallet.ui.dashpay.work.UpdateProfileOperation
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
+import java.nio.channels.FileChannel
+
 
 class EditProfileViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val log = LoggerFactory.getLogger(EditProfileViewModel::class.java)
     private val walletApplication = application as WalletApplication
 
-    private val profilePicturePath = application.cacheDir.absolutePath + "/profile/profileimage.jpg"
+    val profilePictureFile by lazy {
+        try {
+            val storageDir: File = application.getExternalFilesDir(Environment.DIRECTORY_PICTURES)!!
+            File(storageDir, Constants.Files.PROFILE_PICTURE_FILENAME)
+        } catch (ex: IOException) {
+            log.error(ex.message, ex)
+            null
+        }
+    }
+
+    val onTmpPictureReadyForEditEvent = SingleLiveEvent<File>()
+
+    lateinit var tmpPictureFile: File
+
+    fun createTmpPictureFile(): Boolean = try {
+        val storageDir: File = walletApplication.getExternalFilesDir(Environment.DIRECTORY_PICTURES)!!
+        tmpPictureFile = File.createTempFile("profileimagetmp", ".jpg", storageDir).apply {
+            deleteOnExit()
+        }
+        true
+    } catch (ex: IOException) {
+        log.error(ex.message, ex)
+        false
+    }
 
     // Use the database instead of PlatformRepo.getBlockchainIdentity, which
     // won't be initialized if there is no username registered
@@ -62,24 +95,31 @@ class EditProfileViewModel(application: Application) : AndroidViewModel(applicat
                 .enqueue()
     }
 
-    // TODO: Should this be a live data?
-    var localProfileImageUri: String
-        get() = walletApplication.configuration.localProfilePictureUri
-        set(value) {
-            walletApplication.configuration.localProfilePictureUri = value
-        }
+    fun saveTmpAsProfilePicture() {
+        copyFile(tmpPictureFile, profilePictureFile!!)
+    }
 
-    fun saveBitmap(bitmap: Bitmap) {
-        viewModelScope.launch {
-            try {
-                FileOutputStream(profilePicturePath).use { out ->
-                    bitmap.compress(Bitmap.CompressFormat.PNG, 100, out) // bmp is your Bitmap instance
-                }
-            } catch (e: IOException) {
-                e.printStackTrace()
-            }
-            localProfileImageUri = profilePicturePath
+    fun saveAsProfilePictureTmp(picturePath: String) {
+        viewModelScope.launch() {
+            copyFile(File(picturePath), tmpPictureFile)
+            onTmpPictureReadyForEditEvent.call(tmpPictureFile)
         }
     }
 
+    private fun copyFile(srcFile: File, outFile: File) {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val inStream = FileInputStream(srcFile)
+                val outStream = FileOutputStream(outFile)
+                val inChannel: FileChannel = inStream.channel
+                val outChannel: FileChannel = outStream.channel
+                inChannel.transferTo(0, inChannel.size(), outChannel)
+                inStream.close()
+                outStream.close()
+
+            } catch (e: IOException) {
+                e.printStackTrace()
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->
Base on https://developer.android.com/training/camera/photobasics#kotlin
and https://medium.com/@quiro91/sharing-files-through-intents-part-2-fixing-the-permissions-before-lollipop-ceb9bb0eec3a

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
https://dashpay.atlassian.net/browse/NMA-418
## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->
https://github.com/dashevo/dash-wallet/pull/528
## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
