### PR TITLE
Fixed Imgur upload crashes

### DIFF
--- a/wallet/AndroidManifest.xml
+++ b/wallet/AndroidManifest.xml
@@ -56,6 +56,7 @@
 
     <application
         android:networkSecurityConfig="@xml/network_security_config"
+        android:requestLegacyExternalStorage="true"
         android:name="de.schildbach.wallet.WalletApplication"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"

--- a/wallet/proguard.cfg
+++ b/wallet/proguard.cfg
@@ -109,3 +109,6 @@
   public *;
 }
 
+-keepclassmembers class kotlin.Metadata {
+    public <methods>;
+}

--- a/wallet/src/de/schildbach/wallet/data/ImgurUploadResponse.kt
+++ b/wallet/src/de/schildbach/wallet/data/ImgurUploadResponse.kt
@@ -1,3 +1,6 @@
 package de.schildbach.wallet.data
 
+import androidx.annotation.Keep
+
+@Keep
 data class ImgurUploadResponse(val status: Int, val success: Boolean, val data: ImgurImg)

--- a/wallet/src/de/schildbach/wallet/ui/EditProfileActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/EditProfileActivity.kt
@@ -23,6 +23,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.database.Cursor
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.RectF
 import android.net.Uri
 import android.os.Build
@@ -50,6 +52,9 @@ import de.schildbach.wallet.ui.dashpay.utils.ProfilePictureDisplay
 import de.schildbach.wallet_test.R
 import kotlinx.android.synthetic.main.activity_edit_profile.*
 import java.io.File
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.io.InputStream
 
 class EditProfileActivity : BaseMenuActivity() {
 
@@ -331,15 +336,19 @@ class EditProfileActivity : BaseMenuActivity() {
                 }
                 REQUEST_CODE_URI -> if (resultCode == RESULT_OK && data != null) {
                     val selectedImage: Uri? = data.data
-                    val filePathColumn = arrayOf(MediaStore.Images.Media.DATA)
                     if (selectedImage != null) {
+                        val filePathColumn = arrayOf(MediaStore.Images.Media.DATA)
                         val cursor: Cursor? = contentResolver.query(selectedImage,
                                 filePathColumn, null, null, null)
                         if (cursor != null) {
                             cursor.moveToFirst()
                             val columnIndex: Int = cursor.getColumnIndex(filePathColumn[0])
-                            val picturePath: String = cursor.getString(columnIndex)
-                            editProfileViewModel.saveAsProfilePictureTmp(picturePath)
+                            val picturePath: String? = cursor.getString(columnIndex)
+                            if (picturePath != null) {
+                                editProfileViewModel.saveAsProfilePictureTmp(picturePath)
+                            } else {
+                                saveImageWithAuthority(selectedImage)
+                            }
                             cursor.close()
                         }
                     }
@@ -353,6 +362,26 @@ class EditProfileActivity : BaseMenuActivity() {
                             editProfileViewModel.uploadToImgUr()
                         }
                     }
+                }
+            }
+        }
+    }
+
+    private fun saveImageWithAuthority(uri: Uri) {
+        var inputStream: InputStream? = null
+        if (uri.authority != null) {
+            try {
+                inputStream = contentResolver.openInputStream(uri)
+                val bmp: Bitmap = BitmapFactory.decodeStream(inputStream)
+                editProfileViewModel.saveExternalBitmap(bmp)
+            } catch (e: FileNotFoundException) {
+                e.printStackTrace()
+                Toast.makeText(this, e.message, Toast.LENGTH_LONG).show()
+            } finally {
+                try {
+                    inputStream?.close()
+                } catch (e: IOException) {
+                    // ignore
                 }
             }
         }

--- a/wallet/src/de/schildbach/wallet/ui/dashpay/EditProfileViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/EditProfileViewModel.kt
@@ -30,6 +30,7 @@ import de.schildbach.wallet.ui.dashpay.work.UpdateProfileOperation
 import de.schildbach.wallet.ui.dashpay.work.UpdateProfileStatusLiveData
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import okhttp3.*
 import org.slf4j.LoggerFactory
 import java.io.File
@@ -167,8 +168,12 @@ class EditProfileViewModel(application: Application) : BaseProfileViewModel(appl
         if (!tmpPictureFile.exists()) {
             tmpPictureFile.createNewFile()
         }
-        if (bitmap.compress(Bitmap.CompressFormat.JPEG, 100, FileOutputStream(tmpPictureFile))) {
-            onTmpPictureReadyForEditEvent.postValue(tmpPictureFile)
+        viewModelScope.launch(Dispatchers.IO) {
+            if (bitmap.compress(Bitmap.CompressFormat.JPEG, 100, FileOutputStream(tmpPictureFile))) {
+                withContext(Dispatchers.Main) {
+                    onTmpPictureReadyForEditEvent.postValue(tmpPictureFile)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixed KotlinReflectionInternalError: Could not compute caller for function: public constructor ImgurUploadResponse crash

<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
