### PR TITLE
DashPay: Only add new ContactRequests to the db/listeners

### DIFF
--- a/wallet/src/de/schildbach/wallet/data/DashPayContactRequestDao.kt
+++ b/wallet/src/de/schildbach/wallet/data/DashPayContactRequestDao.kt
@@ -19,6 +19,9 @@ interface DashPayContactRequestDao {
     @Query("SELECT * FROM dashpay_contact_request WHERE toUserId = :toUserId")
     suspend fun loadFromOthers(toUserId: String): List<DashPayContactRequest>?
 
+    @Query("SELECT EXISTS (SELECT * FROM dashpay_contact_request WHERE userId = :userId AND toUserId = :toUserId)")
+    suspend fun exists(userId: String, toUserId: String): Boolean
+
     @Query("SELECT MAX(timestamp) FROM dashpay_contact_request")
     suspend fun getLastTimestamp() : Long
 

--- a/wallet/src/de/schildbach/wallet/ui/dashpay/PlatformRepo.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/PlatformRepo.kt
@@ -810,8 +810,15 @@ class PlatformRepo private constructor(val walletApplication: WalletApplication)
             Context.propagate(walletApplication.wallet.context)
             var encryptionKey: KeyParameter? = null
 
-            var lastContactRequestTime = if (dashPayContactRequestDao.countAllRequests() > 0)
-                dashPayContactRequestDao.getLastTimestamp() - DateUtils.MINUTE_IN_MILLIS * 12
+            var lastContactRequestTime = if (dashPayContactRequestDao.countAllRequests() > 0) {
+                val lastTimeStamp = dashPayContactRequestDao.getLastTimestamp()
+                // if the last contact request was received in the past 10 minutes, then query for
+                // contact requests that are 10 minutes before it.  If the last contact request was
+                // more than 10 minutes ago, then query all contact requests that came after it.
+                if (lastTimeStamp < System.currentTimeMillis() - DateUtils.MINUTE_IN_MILLIS * 10)
+                    lastTimeStamp
+                else lastTimeStamp - DateUtils.MINUTE_IN_MILLIS * 10
+            }
             else 0L
 
             updatingContacts.set(true)
@@ -821,50 +828,56 @@ class PlatformRepo private constructor(val walletApplication: WalletApplication)
             val toContactDocuments = ContactRequests(platform).get(userId, toUserId = false, afterTime = lastContactRequestTime, retrieveAll = true)
             toContactDocuments.forEach {
                 val contactRequest = DashPayContactRequest.fromDocument(it)
-                userIdList.add(contactRequest.toUserId)
-                dashPayContactRequestDao.insert(contactRequest)
+                if (!dashPayContactRequestDao.exists(contactRequest.userId, contactRequest.toUserId)) {
 
-                // add our receiving from this contact keychain if it doesn't exist
-                val contact = EvolutionContact(userId, contactRequest.toUserId)
-                try {
-                    if (!walletApplication.wallet.hasReceivingKeyChain(contact)) {
-                        val contactIdentity = platform.identities.get(contactRequest.toUserId)
-                        if (encryptionKey == null && walletApplication.wallet.isEncrypted) {
-                            val password = securityGuard.retrievePassword()
-                            // Don't bother with DeriveKeyTask here, just call deriveKey
-                            encryptionKey = walletApplication.wallet!!.keyCrypter!!.deriveKey(password)
+                    userIdList.add(contactRequest.toUserId)
+                    dashPayContactRequestDao.insert(contactRequest)
+
+                    // add our receiving from this contact keychain if it doesn't exist
+                    val contact = EvolutionContact(userId, contactRequest.toUserId)
+                    try {
+                        if (!walletApplication.wallet.hasReceivingKeyChain(contact)) {
+                            val contactIdentity = platform.identities.get(contactRequest.toUserId)
+                            if (encryptionKey == null && walletApplication.wallet.isEncrypted) {
+                                val password = securityGuard.retrievePassword()
+                                // Don't bother with DeriveKeyTask here, just call deriveKey
+                                encryptionKey = walletApplication.wallet!!.keyCrypter!!.deriveKey(password)
+                            }
+                            blockchainIdentity.addPaymentKeyChainFromContact(contactIdentity!!, it, encryptionKey!!)
+                            addedContact = true
                         }
-                        blockchainIdentity.addPaymentKeyChainFromContact(contactIdentity!!, it, encryptionKey!!)
-                        addedContact = true
+                    } catch (e: KeyCrypterException) {
+                        // we can't send payments to this contact due to an invalid encryptedPublicKey
+                        log.info("ContactRequest: error ${e.message}")
                     }
-                } catch (e: KeyCrypterException) {
-                    // we can't send payments to this contact due to an invalid encryptedPublicKey
-                    log.info("ContactRequest: error ${e.message}")
                 }
             }
             // Get all contact requests where toUserId == userId, the users who have added me
             val fromContactDocuments = ContactRequests(platform).get(userId, toUserId = true, afterTime = lastContactRequestTime, retrieveAll = true)
             fromContactDocuments.forEach {
                 val contactRequest = DashPayContactRequest.fromDocument(it)
-                userIdList.add(contactRequest.userId)
-                dashPayContactRequestDao.insert(contactRequest)
+                if (!dashPayContactRequestDao.exists(contactRequest.userId, contactRequest.toUserId)) {
 
-                // add the sending to contact keychain if it doesn't exist
-                val contact = EvolutionContact(userId, contactRequest.userId)
-                try {
-                    if (!walletApplication.wallet.hasSendingKeyChain(contact)) {
-                        val contactIdentity = platform.identities.get(contactRequest.userId)
-                        if (encryptionKey == null && walletApplication.wallet.isEncrypted) {
-                            val password = securityGuard.retrievePassword()
-                            // Don't bother with DeriveKeyTask here, just call deriveKey
-                            encryptionKey = walletApplication.wallet!!.keyCrypter!!.deriveKey(password)
+                    userIdList.add(contactRequest.userId)
+                    dashPayContactRequestDao.insert(contactRequest)
+
+                    // add the sending to contact keychain if it doesn't exist
+                    val contact = EvolutionContact(userId, contactRequest.userId)
+                    try {
+                        if (!walletApplication.wallet.hasSendingKeyChain(contact)) {
+                            val contactIdentity = platform.identities.get(contactRequest.userId)
+                            if (encryptionKey == null && walletApplication.wallet.isEncrypted) {
+                                val password = securityGuard.retrievePassword()
+                                // Don't bother with DeriveKeyTask here, just call deriveKey
+                                encryptionKey = walletApplication.wallet!!.keyCrypter!!.deriveKey(password)
+                            }
+                            blockchainIdentity.addContactPaymentKeyChain(contactIdentity!!, it, encryptionKey!!)
+                            addedContact = true
                         }
-                        blockchainIdentity.addContactPaymentKeyChain(contactIdentity!!, it, encryptionKey!!)
-                        addedContact = true
+                    } catch (e: KeyCrypterException) {
+                        // we can't send payments to this contact due to an invalid encryptedPublicKey
+                        log.info("ContactRequest: error ${e.message}")
                     }
-                } catch (e: KeyCrypterException) {
-                    // we can't send payments to this contact due to an invalid encryptedPublicKey
-                    log.info("ContactRequest: error ${e.message}")
                 }
             }
 
@@ -884,7 +897,7 @@ class PlatformRepo private constructor(val walletApplication: WalletApplication)
             updateContactProfiles(userId!!, lastContactRequestTime)
 
             // fire listeners if there were new contacts
-            if (fromContactDocuments.isNotEmpty() || toContactDocuments.isNotEmpty()) {
+            if (addedContact) {
                 fireContactsUpdatedListeners()
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
NMA-715
Originally, the app would always get the most recent contact request during a query, but this will modify it so that if it does get a contact request that we already have, then it is ignored.  Additionally, after a short period of time of receiving a contact request, it won't be included in future queries.

as a result, the contacts updated listeners won't be triggered every 15 seconds, when there are no new contact requests.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
