### PR TITLE
NMA-762: DashPay:  Fix Edit Profile - forgets any changes

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/EditProfileActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/EditProfileActivity.kt
@@ -258,6 +258,7 @@ class EditProfileActivity : BaseMenuActivity() {
                 editProfileViewModel.avatarHash = externalUrlSharedViewModel.avatarHash
                 editProfileViewModel.avatarFingerprint = externalUrlSharedViewModel.avatarFingerprint
                 editProfileViewModel.saveExternalBitmap(it)
+                setEditingState(true)
             } else {
                 val username = editProfileViewModel.dashPayProfile!!.username
                 ProfilePictureDisplay.displayDefault(dashpayUserAvatar, username)

--- a/wallet/src/de/schildbach/wallet/ui/EditProfileActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/EditProfileActivity.kt
@@ -364,11 +364,13 @@ class EditProfileActivity : BaseMenuActivity() {
     }
 
     private fun showProfileInfo(profile: DashPayProfile) {
-        ProfilePictureDisplay.display(dashpayUserAvatar, profile)
-        initialAboutMe = profile.publicMessage
-        initialDisplayName = profile.displayName
-        about_me.setText(profile.publicMessage)
-        display_name.setText(profile.displayName)
+        if (!isEditing) {
+            ProfilePictureDisplay.display(dashpayUserAvatar, profile)
+            initialAboutMe = profile.publicMessage
+            initialDisplayName = profile.displayName
+            about_me.setText(profile.publicMessage)
+            display_name.setText(profile.displayName)
+        }
     }
 
     private fun setEditingState(isEditing: Boolean) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
NMA-762

This should prevent the edit profile screen from forgetting changes made to the profile before saving.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->
None
## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->
None
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
