### PR TITLE
NMA-818 DashPay:  Hide Invite Entry Points

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/Configuration.java
+++ b/common/src/main/java/org/dash/wallet/common/Configuration.java
@@ -80,6 +80,7 @@ public class Configuration {
     public static final String PREFS_LAST_SEEN_NOTIFICATION_TIME = "last_seen_notification_time";
     private static final String PREFS_IMGUR_DELETE_HASH = "imgur_delete_hash";
     private static final String PREFS_UPLOAD_POLICY = "upload_policy_accepted_";
+    private static final String PREFS_DEV_MODE = "developer_mode";
 
     private static final int PREFS_DEFAULT_BTC_SHIFT = 0;
     private static final int PREFS_DEFAULT_BTC_PRECISION = 8;
@@ -450,5 +451,12 @@ public class Configuration {
     }
     public void setAcceptedUploadPolicy(String service, Boolean accepted) {
         prefs.edit().putBoolean(PREFS_UPLOAD_POLICY + service, accepted).apply();
+    }
+
+    public Boolean getDeveloperMode() {
+        return prefs.getBoolean(PREFS_DEV_MODE, false);
+    }
+    public void setDeveloperMode(boolean activate) {
+        prefs.edit().putBoolean(PREFS_DEV_MODE, activate).apply();
     }
 }

--- a/wallet/res/layout/activity_search_dashpay_profile_1.xml
+++ b/wallet/res/layout/activity_search_dashpay_profile_1.xml
@@ -98,7 +98,7 @@
     <include layout="@layout/user_search_loading" />
 
     <include
-        android:id="@+id/invite_friend_hint_view_dashpay_provile_1"
+        android:id="@+id/invite_friend_hint_view_dashpay_profile_1"
         layout="@layout/invite_friend_hint_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -555,4 +555,5 @@
     <string name="network_error_contact_suggestions">Unable to provide suggestions</string>
     <string name="network_error_unable_to_update_profile">Unable to update your profile</string>
 
+    <string name="about_developer_mode">Developer mode activated: all features enabled!</string>
 </resources>

--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -556,4 +556,5 @@
     <string name="network_error_unable_to_update_profile">Unable to update your profile</string>
 
     <string name="about_developer_mode">Developer mode activated: all features enabled!</string>
+    <string name="about_developer_mode_disabled">Developer mode deactivated.</string>
 </resources>

--- a/wallet/src/de/schildbach/wallet/ui/AboutActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/AboutActivity.kt
@@ -133,12 +133,17 @@ class AboutActivity : BaseMenuActivity(), SensorEventListener {
                 val acceleration = sqrt(x.toDouble().pow(2.0) +
                         y.toDouble().pow(2.0) +
                         z.toDouble().pow(2.0)) - SensorManager.GRAVITY_EARTH
-                //log.info("Acceleration is " + acceleration + "m/s^2")
+
                 if (acceleration > SHAKE_THRESHOLD) {
                     mLastShakeTime = curTime
-                    log.info("Shake, Rattle, and Roll")
-                    configuration.developerMode = true
-                    Toast.makeText(this, R.string.about_developer_mode, LENGTH_LONG).show()
+                    log.info("Shake detected: developer mode changing to ${!configuration.developerMode}")
+                    configuration.developerMode = if (!configuration.developerMode) {
+                        Toast.makeText(this, R.string.about_developer_mode, LENGTH_LONG).show()
+                        true
+                    } else {
+                        Toast.makeText(this, R.string.about_developer_mode_disabled, LENGTH_LONG).show()
+                        false
+                    }
                 }
             }
         }

--- a/wallet/src/de/schildbach/wallet/ui/AboutActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/AboutActivity.kt
@@ -19,17 +19,37 @@ package de.schildbach.wallet.ui
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.Intent.ACTION_VIEW
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
 import android.net.Uri
 import android.os.Bundle
+import android.widget.Toast
+import android.widget.Toast.LENGTH_LONG
 import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet_test.BuildConfig
 import de.schildbach.wallet_test.R
 import kotlinx.android.synthetic.main.activity_about.*
 import org.bitcoinj.core.VersionMessage
 import org.dash.wallet.common.UserInteractionAwareCallback
+import org.slf4j.LoggerFactory
+import kotlin.math.pow
+import kotlin.math.sqrt
 
 
-class AboutActivity : BaseMenuActivity() {
+class AboutActivity : BaseMenuActivity(), SensorEventListener {
+
+    // variables for shake detection
+    private val SHAKE_THRESHOLD = 1.50f // m/S**2
+
+    private val MIN_TIME_BETWEEN_SHAKES_MILLISECS = 1000
+    private var mLastShakeTime: Long = 0
+    private lateinit var mSensorMgr: SensorManager
+
+    companion object {
+        private val log = LoggerFactory.getLogger(AboutActivity::class.java)
+    }
 
     override fun getLayoutId(): Int {
         return R.layout.activity_about
@@ -50,7 +70,32 @@ class AboutActivity : BaseMenuActivity() {
         }
         review_and_rate.setOnClickListener { openReviewAppIntent() }
         contact_support.setOnClickListener { handleReportIssue() }
+
+        // Get a sensor manager to listen for shakes
+
+        // Get a sensor manager to listen for shakes
+        mSensorMgr = getSystemService(SENSOR_SERVICE) as SensorManager
     }
+
+    override fun onResume() {
+        super.onResume()
+        // Listen for shakes
+        val accelerometer = mSensorMgr.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+        if (accelerometer != null) {
+            mSensorMgr.registerListener(this, accelerometer, SensorManager.SENSOR_DELAY_NORMAL)
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        // stop listening for shakes
+        val accelerometer = mSensorMgr.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+        if (accelerometer != null) {
+            mSensorMgr.unregisterListener(this)
+        }
+    }
+
+
 
     override fun finish() {
         super.finish()
@@ -76,6 +121,31 @@ class AboutActivity : BaseMenuActivity() {
         val dialog = ReportIssueDialogBuilder.createReportIssueDialog(this,
                 WalletApplication.getInstance()).show()
         dialog.window!!.callback = UserInteractionAwareCallback(dialog.window!!.callback, this)
+    }
+
+    override fun onSensorChanged(event: SensorEvent?) {
+        if (event != null && event.sensor.type == Sensor.TYPE_ACCELEROMETER) {
+            val curTime = System.currentTimeMillis()
+            if (curTime - mLastShakeTime > MIN_TIME_BETWEEN_SHAKES_MILLISECS) {
+                val x = event.values[0]
+                val y = event.values[1]
+                val z = event.values[2]
+                val acceleration = sqrt(x.toDouble().pow(2.0) +
+                        y.toDouble().pow(2.0) +
+                        z.toDouble().pow(2.0)) - SensorManager.GRAVITY_EARTH
+                //log.info("Acceleration is " + acceleration + "m/s^2")
+                if (acceleration > SHAKE_THRESHOLD) {
+                    mLastShakeTime = curTime
+                    log.info("Shake, Rattle, and Roll")
+                    configuration.developerMode = true
+                    Toast.makeText(this, R.string.about_developer_mode, LENGTH_LONG).show()
+                }
+            }
+        }
+    }
+
+    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
+        // Ignore
     }
 
 }

--- a/wallet/src/de/schildbach/wallet/ui/CreateUsernameActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/CreateUsernameActivity.kt
@@ -148,23 +148,25 @@ class CreateUsernameActivity : InteractionAwareActivity(), TextWatcher {
     }
 
     private fun handleIntent(intent: Intent) {
-        FirebaseDynamicLinks.getInstance()
-                .getDynamicLink(intent)
-                .addOnSuccessListener {
-                    log.debug("dynamic link received")
-                    if (it != null) {
-                        log.debug("${it.extensions}; ${it.link}")
-                        val appLinkData = Constants.Invitation.AppLinkData(it.link!!)
-                        dashPayViewModel.dashPayProfileData(appLinkData.username).observe(this, { dashPayProfile ->
-                            if (dashPayProfile != null) {
-                                showPreviewDialog(dashPayProfile)
-                            } else {
-                                Toast.makeText(this, "Unable to find user ${appLinkData.username}", Toast.LENGTH_LONG).show()
-                                log.error("unable to find inviting user ${it.link}")
-                            }
-                        })
+        if (walletApplication.configuration.developerMode) {
+            FirebaseDynamicLinks.getInstance()
+                    .getDynamicLink(intent)
+                    .addOnSuccessListener {
+                        log.debug("dynamic link received")
+                        if (it != null) {
+                            log.debug("${it.extensions}; ${it.link}")
+                            val appLinkData = Constants.Invitation.AppLinkData(it.link!!)
+                            dashPayViewModel.dashPayProfileData(appLinkData.username).observe(this, { dashPayProfile ->
+                                if (dashPayProfile != null) {
+                                    showPreviewDialog(dashPayProfile)
+                                } else {
+                                    Toast.makeText(this, "Unable to find user ${appLinkData.username}", Toast.LENGTH_LONG).show()
+                                    log.error("unable to find inviting user ${it.link}")
+                                }
+                            })
+                        }
                     }
-                }
+        }
     }
 
     private fun showPreviewDialog(dashPayProfile: DashPayProfile) {

--- a/wallet/src/de/schildbach/wallet/ui/MainActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/MainActivity.kt
@@ -154,12 +154,14 @@ class MainActivity : AbstractBindServiceActivity(), ActivityCompat.OnRequestPerm
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
         handleIntent(intent!!)
-        Log.i("FirebaseDynamicLinks2", "We have a dynamic link! $intent")
-        FirebaseDynamicLinks.getInstance().getDynamicLink(intent).addOnSuccessListener {
-            if (it != null) {
-                Log.i("FirebaseDynamicLinks2", "We have a dynamic link! ${it.extensions}; ${it.link}")
-                val nameLabel = it.link!!.getQueryParameter("displayName") ?: ""
-                showPreviewDialog(nameLabel)
+        if (walletApplication.configuration.developerMode) {
+            Log.i("FirebaseDynamicLinks2", "We have a dynamic link! $intent")
+            FirebaseDynamicLinks.getInstance().getDynamicLink(intent).addOnSuccessListener {
+                if (it != null) {
+                    Log.i("FirebaseDynamicLinks2", "We have a dynamic link! ${it.extensions}; ${it.link}")
+                    val nameLabel = it.link!!.getQueryParameter("displayName") ?: ""
+                    showPreviewDialog(nameLabel)
+                }
             }
         }
     }

--- a/wallet/src/de/schildbach/wallet/ui/MoreFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/MoreFragment.kt
@@ -194,9 +194,19 @@ class MoreFragment : BottomNavFragment(R.layout.activity_more) {
         edit_profile.setOnClickListener {
             startActivity(Intent(requireContext(), EditProfileActivity::class.java))
         }
-        //Developer Mode Feature
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // Developer Mode Feature
+        initDeveloperMode()
+    }
+
+    private fun initDeveloperMode() {
         if (walletApplication.configuration.developerMode) {
             invite.visibility = View.VISIBLE
+        } else {
+            invite.visibility = View.GONE
         }
     }
 

--- a/wallet/src/de/schildbach/wallet/ui/MoreFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/MoreFragment.kt
@@ -50,6 +50,7 @@ class MoreFragment : BottomNavFragment(R.layout.activity_more) {
     private var blockchainState: BlockchainState? = null
     private lateinit var editProfileViewModel: EditProfileViewModel
     private lateinit var mainActivityViewModel: MainActivityViewModel
+    private val walletApplication = WalletApplication.getInstance()
 
     companion object {
         const val PROFILE_VIEW = 0
@@ -193,7 +194,10 @@ class MoreFragment : BottomNavFragment(R.layout.activity_more) {
         edit_profile.setOnClickListener {
             startActivity(Intent(requireContext(), EditProfileActivity::class.java))
         }
-        invite.visibility = View.VISIBLE
+        //Developer Mode Feature
+        if (walletApplication.configuration.developerMode) {
+            invite.visibility = View.VISIBLE
+        }
     }
 
     override fun startActivity(intent: Intent) {

--- a/wallet/src/de/schildbach/wallet/ui/SearchUserActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SearchUserActivity.kt
@@ -133,7 +133,7 @@ class SearchUserActivity : InteractionAwareActivity(), TextWatcher, ContactViewH
                     override fun onTransitionStart(transition: Transition) {
                         layout_title.visibility = View.GONE
                         find_a_user_label.visibility = View.GONE
-                        invite_friend_hint_view_dashpay_provile_1.visibility = View.GONE
+                        invite_friend_hint_view_dashpay_profile_1.visibility = View.GONE
                     }
 
                 })
@@ -153,7 +153,13 @@ class SearchUserActivity : InteractionAwareActivity(), TextWatcher, ContactViewH
             search.setText(initQuery)
         }
 
-        invite_friend_hint_view_dashpay_provile_1.setOnClickListener {
+        //Developer Mode Feature
+        if (!walletApplication.configuration.developerMode) {
+            invite_friend_hint_view_dashpay_profile_1.visibility = View.GONE
+            invite_friend_hint_view_empty_result.visibility = View.GONE //this line doesn't hide the invite Layout item
+        }
+
+        invite_friend_hint_view_dashpay_profile_1.setOnClickListener {
             InviteFriendActivity.startOrError(this)
         }
         invite_friend_hint_view_empty_result.setOnClickListener {

--- a/wallet/src/de/schildbach/wallet/ui/dashpay/ContactsFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/ContactsFragment.kt
@@ -31,6 +31,7 @@ import androidx.core.text.HtmlCompat
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
+import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet.data.BlockchainState
 import de.schildbach.wallet.data.PaymentIntent
 import de.schildbach.wallet.data.UsernameSearchResult
@@ -44,6 +45,7 @@ import de.schildbach.wallet.util.KeyboardUtil
 import de.schildbach.wallet_test.R
 import kotlinx.android.synthetic.main.contacts_list_layout.*
 import kotlinx.android.synthetic.main.contacts_list_layout.icon
+import kotlinx.android.synthetic.main.contacts_list_layout.search
 import kotlinx.android.synthetic.main.invite_friend_hint_view.*
 import kotlinx.android.synthetic.main.network_unavailable.*
 import kotlinx.android.synthetic.main.no_contacts_results.*
@@ -138,6 +140,12 @@ class ContactsFragment : BottomNavFragment(R.layout.fragment_contacts_root), Tex
             onSearchUser()
         }
         searchContacts()
+
+        // Developer Mode Feature
+        // Hide the invite UI
+        if (!WalletApplication.getInstance().configuration.developerMode) {
+            invite_friend_hint.visibility = View.GONE
+        }
 
         invite_friend_hint.setOnClickListener {
             InviteFriendActivity.startOrError(requireActivity())

--- a/wallet/src/de/schildbach/wallet/ui/dashpay/ContactsFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/ContactsFragment.kt
@@ -43,6 +43,7 @@ import de.schildbach.wallet.ui.invite.InviteFriendActivity
 import de.schildbach.wallet.ui.send.SendCoinsInternalActivity
 import de.schildbach.wallet.util.KeyboardUtil
 import de.schildbach.wallet_test.R
+import kotlinx.android.synthetic.main.contacts_empty_state_layout.*
 import kotlinx.android.synthetic.main.contacts_list_layout.*
 import kotlinx.android.synthetic.main.contacts_list_layout.icon
 import kotlinx.android.synthetic.main.contacts_list_layout.search
@@ -132,7 +133,7 @@ class ContactsFragment : BottomNavFragment(R.layout.fragment_contacts_root), Tex
             }
         }
 
-        search_for_user_suggestions.setOnClickListener {
+        search_for_user.setOnClickListener {
             onSearchUser()
         }
 

--- a/wallet/src/de/schildbach/wallet/ui/dashpay/NotificationsActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/NotificationsActivity.kt
@@ -161,8 +161,11 @@ class NotificationsActivity : InteractionAwareActivity(), TextWatcher,
         log.info("New contacts at ${Date(newDate)} = ${newItems.size} - NotificationActivity")
 
         //Add User Alert item
-        userAlertItem?.apply {
-            results.add(NotificationsAdapter.NotificationViewItem(this))
+        //Developer Mode Feature
+        if (walletApplication.configuration.developerMode) {
+            userAlertItem?.apply {
+                results.add(NotificationsAdapter.NotificationViewItem(this))
+            }
         }
 
         results.add(NotificationsAdapter.HeaderViewItem(1, R.string.notifications_new))

--- a/wallet/src/de/schildbach/wallet/ui/dashpay/PlatformRepo.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/PlatformRepo.kt
@@ -424,9 +424,12 @@ class PlatformRepo private constructor(val walletApplication: WalletApplication)
 
     suspend fun getNotificationCount(date: Long): Int {
         var count = 0
-        val alert = userAlertDao.load(date)
-        if (alert != null) {
-            count++
+        // Developer Mode Feature
+        if (walletApplication.configuration.developerMode) {
+            val alert = userAlertDao.load(date)
+            if (alert != null) {
+                count++
+            }
         }
         val results = searchContacts("", UsernameSortOrderBy.DATE_ADDED)
         if (results.status == Status.SUCCESS) {

--- a/wallet/src/de/schildbach/wallet/ui/invite/InviteFriendActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/invite/InviteFriendActivity.kt
@@ -45,7 +45,7 @@ class InviteFriendActivity : InteractionAwareActivity() {
                 activity.startActivity(createIntent(activity))
             } else {
                 val title = activity.getString(R.string.invitation_cant_afford_title)
-                val message = activity.getString(R.string.invitation_cant_afford_message, Constants.DASH_PAY_FEE)
+                val message = activity.getString(R.string.invitation_cant_afford_message, Constants.DASH_PAY_FEE.toPlainString())
                 val errorDialog = FancyAlertDialog.newInstance(title, message,
                         R.drawable.ic_cant_afford_invitation, 0, R.string.invitation_preview_close)
                 errorDialog.show(activity.supportFragmentManager, null)

--- a/wallet/src/de/schildbach/wallet/ui/widget/KeyboardResponsiveConstraintLayout.java
+++ b/wallet/src/de/schildbach/wallet/ui/widget/KeyboardResponsiveConstraintLayout.java
@@ -26,7 +26,6 @@ import android.view.ViewTreeObserver;
 
 import androidx.annotation.Nullable;
 import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 import de.schildbach.wallet_test.R;
 
@@ -37,6 +36,7 @@ public class KeyboardResponsiveConstraintLayout extends ConstraintLayout {
 
     private final int idOfViewToHide;
     private @Nullable View viewToHide;
+    private int initialVisibility;  //preserve the original visibility of viewToHide
 
     public KeyboardResponsiveConstraintLayout(Context context) {
         this(context, null);
@@ -72,7 +72,8 @@ public class KeyboardResponsiveConstraintLayout extends ConstraintLayout {
                 if (difference > 0) {
                     viewToHide.setVisibility(View.GONE);
                 } else {
-                    viewToHide.setVisibility(View.VISIBLE);
+                    if (initialVisibility == View.VISIBLE)
+                        viewToHide.setVisibility(View.VISIBLE);
                 }
             }
         }
@@ -96,6 +97,7 @@ public class KeyboardResponsiveConstraintLayout extends ConstraintLayout {
 
         if (idOfViewToHide != -1) {
             viewToHide = findViewById(idOfViewToHide);
+            initialVisibility = viewToHide.getVisibility();
         }
     }
 
@@ -106,5 +108,6 @@ public class KeyboardResponsiveConstraintLayout extends ConstraintLayout {
         getViewTreeObserver().removeOnGlobalLayoutListener(layoutListener);
 
         viewToHide = null;
+        initialVisibility = View.VISIBLE;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

To allow for QA testing before all invitation features are completed, I would like to be able to show/hide the entry points.

Acceptance Criteria

- The invitation entry points should be hidden by default

- Invitation notifications should be suppressed if the entry points are hidden

- The user should be able to show/hide the entry points after shaking the device in the About screen

Screens affected

- Contacts Screen (with no contacts)

- Search User Screen (before clicking on the search box)

- Search User Screen (after entering a search with no results)

- More Screen

- Notifications Screen

About Screen show say “Developer mode activated” and “Developer mode deactivated” when the screen is shaken.  Activated means that the Invite UI appears at all of the 5 above screens.  Deactivated means that the Invite UI should be hidden (this is the default state when the app is installed)

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [x] I have added or updated relevant unit/integration/functional/e2e tests
