### PR TITLE
NMA-797: DashPay: Prevent Crash when Scanning Own QR Code

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
@@ -57,6 +57,7 @@ import org.bitcoinj.wallet.Wallet.DustySendRequested;
 import org.dash.wallet.common.Configuration;
 import org.dash.wallet.common.ui.DialogBuilder;
 import org.dash.wallet.common.util.GenericUtils;
+import org.dashevo.dashpay.BlockchainIdentity;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -279,8 +280,15 @@ public class SendCoinsFragment extends Fragment {
                 throw new IllegalArgumentException();
             }
 
-            boolean isDashPayUser = PlatformRepo.getInstance().getBlockchainIdentity() != null;
-            if (isDashPayUser && paymentIntent.isIdentityPaymentRequest()) {
+            BlockchainIdentity blockchainIdentity = PlatformRepo.getInstance().getBlockchainIdentity();
+            boolean isDashUserOrNotMe = blockchainIdentity != null;
+            // make sure that this payment intent is not to me
+            if (paymentIntent.isIdentityPaymentRequest() && paymentIntent.payeeUsername != null &&
+                    paymentIntent.payeeUsername.equals(blockchainIdentity.getCurrentUsername())) {
+                isDashUserOrNotMe = false;
+            }
+
+            if (isDashUserOrNotMe && paymentIntent.isIdentityPaymentRequest()) {
                 if (paymentIntent.payeeUsername != null) {
                     viewModel.loadUserDataByUsername(paymentIntent.payeeUsername).observe(getViewLifecycleOwner(), new Observer<Resource<UsernameSearchResult>>() {
                         @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
NMA-797

The app crashed after scanning the wallet's own QR code.  This is like trying to pay ourselves as a contact.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
