### PR TITLE
NMA-828  Home Screen | Pulsing Profile Picture

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/dashpay/utils/ProfilePictureDisplay.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/utils/ProfilePictureDisplay.kt
@@ -26,6 +26,7 @@ import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
+import com.bumptech.glide.signature.ObjectKey
 import de.schildbach.wallet.data.DashPayProfile
 import de.schildbach.wallet.ui.ProfilePictureTransformation
 import de.schildbach.wallet.ui.UserAvatarPlaceholderDrawable.Companion.getDrawable
@@ -64,7 +65,7 @@ class ProfilePictureDisplay {
                 val zoomRectF = ProfilePictureHelper.extractZoomedRect(avatarUrl)
                 val baseAvatarUrl = ProfilePictureHelper.removePicZoomParameter(avatarUrl)
                 val context = avatarView.context.applicationContext
-                val a = Glide.with(context)
+                Glide.with(context)
                         .load(baseAvatarUrl)
                         .listener(object : RequestListener<Drawable> {
                             override fun onLoadFailed(e: GlideException?, model: Any?, target: Target<Drawable>?, isFirstResource: Boolean): Boolean {
@@ -79,7 +80,7 @@ class ProfilePictureDisplay {
                                 return false
                             }
                         })
-                        .signature(ProfilePictureHelper.HashAndZoomSignature(avatarHash, zoomRectF))
+                        .signature(ObjectKey(zoomRectF.hashCode()))
                         .override(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL)
                         .transform(ProfilePictureTransformation.create(avatarUrlStr))
                         .placeholder(defaultAvatar)


### PR DESCRIPTION
Changed the custom signature of profile pictures in order to avoid image pulsing when refreshing the data

<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
