### PR TITLE
NMA-830: DashPay: Don't Show notifications when restoring until after sync is finished

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/Configuration.java
+++ b/common/src/main/java/org/dash/wallet/common/Configuration.java
@@ -85,6 +85,8 @@ public class Configuration {
     private static final int PREFS_DEFAULT_BTC_SHIFT = 0;
     private static final int PREFS_DEFAULT_BTC_PRECISION = 8;
 
+    private static final long DISABLE_NOTIFICATIONS = -1;
+
     private static final Logger log = LoggerFactory.getLogger(Configuration.class);
 
     public Configuration(final SharedPreferences prefs, final Resources res) {
@@ -432,6 +434,14 @@ public class Configuration {
 
     public long getLastSeenNotificationTime() {
         return prefs.getLong(PREFS_LAST_SEEN_NOTIFICATION_TIME, 0);
+    }
+
+    public boolean areNotificationsDisabled() {
+        return getLastSeenNotificationTime() == DISABLE_NOTIFICATIONS;
+    }
+
+    public void disableNotifications() {
+        setLastSeenNotificationTime(DISABLE_NOTIFICATIONS);
     }
 
     public void setLastSeenNotificationTime(long lastSeenNotificationTime) {

--- a/wallet/src/de/schildbach/wallet/ui/HeaderBalanceFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/HeaderBalanceFragment.java
@@ -116,13 +116,16 @@ public final class HeaderBalanceFragment extends Fragment implements SharedPrefe
         viewModel.getNotificationCountData().observe(getViewLifecycleOwner(), notificationCount -> {
             setNotificationCount();
         });
-        long lastSeenNotification = config.getLastSeenNotificationTime();
-        AppDatabase.getAppDatabase().userAlertDaoAsync()
-                .load(lastSeenNotification).observe(getViewLifecycleOwner(), userAlert -> {
-            if (userAlert != null) {
-                viewModel.forceUpdateNotificationCount();
-            }
-        });
+        // don't query alerts if notifications are disabled
+        if (config.areNotificationsDisabled()) {
+            long lastSeenNotification = config.getLastSeenNotificationTime();
+            AppDatabase.getAppDatabase().userAlertDaoAsync()
+                    .load(lastSeenNotification).observe(getViewLifecycleOwner(), userAlert -> {
+                if (userAlert != null) {
+                    viewModel.forceUpdateNotificationCount();
+                }
+            });
+        }
     }
 
     @Override

--- a/wallet/src/de/schildbach/wallet/ui/MainActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/MainActivity.kt
@@ -302,6 +302,7 @@ class MainActivity : AbstractBindServiceActivity(), ActivityCompat.OnRequestPerm
             override fun onRestoreWallet(wallet: Wallet) {
                 restoreWallet(wallet)
                 config.isRestoringBackup = true
+                config.disableNotifications()
             }
 
             override fun onRetryRequest() {

--- a/wallet/src/de/schildbach/wallet/ui/RestoreWalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/RestoreWalletActivity.java
@@ -182,6 +182,7 @@ public final class RestoreWalletActivity extends AbstractWalletActivity
 
             restoreWallet(WalletUtils.restoreWalletFromProtobufOrBase58(is, Constants.NETWORK_PARAMETERS));
             application.getConfiguration().setRestoringBackup(true);
+            application.getConfiguration().disableNotifications();
             log.info("successfully restored encrypted wallet from external source");
         } catch (final IOException x) {
             final DialogBuilder dialog = DialogBuilder.warn(this, R.string.import_export_keys_dialog_failure_title);

--- a/wallet/src/de/schildbach/wallet/ui/RestoreWalletFromFileViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/RestoreWalletFromFileViewModel.kt
@@ -42,6 +42,7 @@ class RestoreWalletFromFileViewModel(application: Application) : AndroidViewMode
             showUpgradeWalletAction.call(wallet)
         } else {
             walletApplication.wallet = wallet
+            walletApplication.configuration.disableNotifications()
             log.info("successfully restored wallet from file")
             walletApplication.resetBlockchainState()
             startActivityAction.call(SetPinActivity.createIntent(getApplication(),

--- a/wallet/src/de/schildbach/wallet/ui/RestoreWalletFromSeedViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/RestoreWalletFromSeedViewModel.kt
@@ -47,6 +47,7 @@ class RestoreWalletFromSeedViewModel(application: Application) : AndroidViewMode
             log.info("successfully restored wallet from seed")
             walletApplication.configuration.disarmBackupSeedReminder()
             walletApplication.configuration.isRestoringBackup = true
+            walletApplication.configuration.disableNotifications()
             walletApplication.resetBlockchainState()
             startActivityAction.call(SetPinActivity.createIntent(getApplication(), R.string.set_pin_restore_wallet))
         }

--- a/wallet/src/de/schildbach/wallet/ui/dashpay/NotificationCountLiveData.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/NotificationCountLiveData.kt
@@ -10,15 +10,19 @@ class NotificationCountLiveData(walletApplication: WalletApplication, platformRe
 
     override fun onContactsUpdated() {
         scope.launch(Dispatchers.IO) {
-            val notificationCount = platformRepo.getNotificationCount(walletApplication.configuration.lastSeenNotificationTime)
+            if (!walletApplication.configuration.areNotificationsDisabled()) {
+                val notificationCount = platformRepo.getNotificationCount(walletApplication.configuration.lastSeenNotificationTime)
 
-            // TODO: Count other types of notifications such as:
-            // * payments
-            // * notifications
+                // TODO: Count other types of notifications such as:
+                // * payments
+                // * notifications
 
-            //TODO: ???
-            if (notificationCount >= 0)
-                postValue(notificationCount)
+                //TODO: ???
+                if (notificationCount >= 0)
+                    postValue(notificationCount)
+            } else {
+                postValue(0)
+            }
         }
     }
 }

--- a/wallet/src/de/schildbach/wallet/ui/dashpay/PlatformRepo.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/PlatformRepo.kt
@@ -1029,6 +1029,10 @@ class PlatformRepo private constructor(val walletApplication: WalletApplication)
 
     private fun finishPreBlockDownload() {
         log.info("PreDownloadBlocks: complete")
+        if (walletApplication.configuration.areNotificationsDisabled()) {
+            // this will enable notifications, since platform information has been synced
+            walletApplication.configuration.lastSeenNotificationTime = System.currentTimeMillis()
+        }
         preDownloadBlocksFuture?.set(true)
         preDownloadBlocks.set(false)
     }


### PR DESCRIPTION
Restoring a wallet is from a file or recovery phrase

Consider all old notifications as Earlier instead of new

<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [X] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code and added comments where necessary
- [X] I have added or updated relevant unit/integration/functional/e2e tests
