### PR TITLE
build: Remove bintray (NMA-821)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,5 @@ allprojects {
         mavenLocal()
         mavenCentral()
         jcenter()
-        maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local' }
     }
 }

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -9,13 +9,6 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        url 'http://oss.jfrog.org/artifactory/oss-snapshot-local'
-        name 'OJO snapshots'
-    }
-    maven {
-        url 'http://dl.bintray.com/dash/Dashj'
-    }
-    maven {
         url 'https://maven.google.com/'
         name 'Google'
     }
@@ -43,9 +36,9 @@ dependencies {
     implementation 'androidx.preference:preference:1.1.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation "org.dashj:dashj-core:$dashjVersion"
-    implementation "org.dashj-android:dashj-bls-android:0.17.5"
-    implementation "org.dashj-android:dashj-x11-android:0.17.5"
-    implementation "org.dashj-android:dashj-scrypt-android:0.17.5"
+    implementation "org.dashj.android:dashj-bls-android:0.17.5"
+    implementation "org.dashj.android:dashj-x11-android:0.17.5"
+    implementation "org.dashj.android:dashj-scrypt-android:0.17.5"
     implementation 'com.google.guava:guava:29.0-android'
     implementation 'com.google.zxing:core:3.3.3'    // 3.3.3 is the maximum to support Android 4.4 to 6.x
     implementation "com.squareup.okhttp3:okhttp:$ok_http_version"


### PR DESCRIPTION
* Our libs are now on maven central

<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
This should be transparent from the user.  Get the dashj-*-android libraries from Maven Central instead of JCenter/bintray
## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
