### PR TITLE
fix: prevent returning to onboarding screen after finishing onboarding (NMA-941)

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/OnboardingActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/OnboardingActivity.kt
@@ -17,6 +17,7 @@
 package de.schildbach.wallet.ui
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.graphics.drawable.LayerDrawable
@@ -39,6 +40,9 @@ import kotlinx.android.synthetic.main.activity_onboarding_perm_lock.*
 import org.dash.wallet.common.ui.DialogBuilder
 
 private const val REGULAR_FLOW_TUTORIAL_REQUEST_CODE = 0
+const val SET_PIN_REQUEST_CODE = 1
+private const val RESTORE_PHRASE_REQUEST_CODE = 2
+private const val RESTORE_FILE_REQUEST_CODE = 3
 
 class OnboardingActivity : RestoreFromFileActivity() {
 
@@ -135,7 +139,7 @@ class OnboardingActivity : RestoreFromFileActivity() {
         }
         recovery_wallet.setOnClickListener {
             walletApplication.initEnvironmentIfNeeded()
-            startActivity(Intent(this, RestoreWalletFromSeedActivity::class.java))
+            startActivityForResult(Intent(this, RestoreWalletFromSeedActivity::class.java), REQUEST_CODE_RESTORE_WALLET)
         }
         restore_wallet.setOnClickListener {
             restoreWalletFromFile()
@@ -161,7 +165,7 @@ class OnboardingActivity : RestoreFromFileActivity() {
             dialog.show()
         })
         viewModel.startActivityAction.observe(this, Observer {
-            startActivity(it)
+            startActivityForResult(it, SET_PIN_REQUEST_CODE)
         })
     }
 
@@ -197,6 +201,8 @@ class OnboardingActivity : RestoreFromFileActivity() {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == REGULAR_FLOW_TUTORIAL_REQUEST_CODE) {
             upgradeOrStartMainActivity()
+        } else if ((requestCode == SET_PIN_REQUEST_CODE || requestCode == RESTORE_PHRASE_REQUEST_CODE) && resultCode == Activity.RESULT_OK) {
+            finish()
         }
     }
 

--- a/wallet/src/de/schildbach/wallet/ui/RestoreWalletFromSeedActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/RestoreWalletFromSeedActivity.kt
@@ -17,6 +17,7 @@
 package de.schildbach.wallet.ui
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -134,7 +135,7 @@ class RestoreWalletFromSeedActivity : RestoreFromFileActivity() {
             }
         })
         viewModel.startActivityAction.observe(this, Observer {
-            startActivity(it)
+            startActivityForResult(it, SET_PIN_REQUEST_CODE)
         })
     }
 
@@ -154,6 +155,14 @@ class RestoreWalletFromSeedActivity : RestoreFromFileActivity() {
             setMessage(errorMessage)
             setPositiveButton(R.string.button_ok, null)
             show()
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == SET_PIN_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            setResult(Activity.RESULT_OK)
+            finish()
         }
     }
 }

--- a/wallet/src/de/schildbach/wallet/ui/SetPinActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SetPinActivity.kt
@@ -16,6 +16,7 @@
 
 package de.schildbach.wallet.ui
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -395,6 +396,7 @@ class SetPinActivity : InteractionAwareActivity() {
             }
         })
         viewModel.startNextActivity.observe(this, Observer {
+            setResult(Activity.RESULT_OK)
             if (it) {
                 startVerifySeedActivity()
             } else {

--- a/wallet/src/de/schildbach/wallet/ui/backup/RestoreFromFileActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/backup/RestoreFromFileActivity.kt
@@ -16,10 +16,10 @@
 
 package de.schildbach.wallet.ui.backup
 
-import android.Manifest
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.app.Dialog
-import android.content.pm.PackageManager
+import android.content.Intent
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.WindowManager
@@ -34,6 +34,7 @@ import de.schildbach.wallet.ui.AbstractPINDialogFragment
 import de.schildbach.wallet.ui.EncryptNewKeyChainDialogFragment
 import de.schildbach.wallet.ui.RestoreWalletFromFileViewModel
 import de.schildbach.wallet.ui.RestoreWalletFromSeedDialogFragment
+import de.schildbach.wallet.ui.SET_PIN_REQUEST_CODE
 import de.schildbach.wallet.ui.widget.UpgradeWalletDisclaimerDialog
 import de.schildbach.wallet_test.R
 import org.bitcoinj.wallet.Wallet
@@ -88,7 +89,7 @@ open class RestoreFromFileActivity : AppCompatActivity(), AbstractPINDialogFragm
             UpgradeWalletDisclaimerDialog.show(supportFragmentManager)
         })
         viewModel.startActivityAction.observe(this, Observer {
-            startActivity(it)
+            startActivityForResult(it, SET_PIN_REQUEST_CODE)
         })
         viewModel.restoreWallet.observe(this, Observer {
             walletBuffer = it
@@ -133,5 +134,13 @@ open class RestoreFromFileActivity : AppCompatActivity(), AbstractPINDialogFragm
     override fun onResume() {
         window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
         super.onResume()
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == SET_PIN_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            setResult(Activity.RESULT_OK)
+            finish()
+        }
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
As of v7.2.4, it was possible to finish onboarding and from the Home Screen return to the Onboarding screen.
## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [x] I have added or updated relevant unit/integration/functional/e2e tests
