### PR TITLE
fix: remove Lock Screen from Tx Details Screen after BIP70 request (NMA-944)

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/send/PaymentProtocolFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/send/PaymentProtocolFragment.kt
@@ -68,6 +68,7 @@ class PaymentProtocolFragment : Fragment() {
         }
     }
 
+    private var userAuthorizedDuring = false
     private lateinit var paymentProtocolModel: PaymentProtocolViewModel
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -211,6 +212,7 @@ class PaymentProtocolFragment : Fragment() {
                     view_flipper.displayedChild = VIEW_LOADING
                 }
                 Status.SUCCESS -> {
+                    userAuthorizedDuring = true
                     paymentProtocolModel.commitAndBroadcast(it.data!!.first)
                 }
                 Status.ERROR -> {
@@ -330,6 +332,6 @@ class PaymentProtocolFragment : Fragment() {
     }
 
     private fun isUserAuthorized(): Boolean {
-        return (activity as SendCoinsActivity).isUserAuthorized
+        return (activity as SendCoinsActivity).isUserAuthorized || userAuthorizedDuring
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
This will prevent the Lock Screen from appearing when a BIP70 payment request is performed by another app.
## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
