### PR TITLE
fix: close pin authentication dialog for view recovery phrase on autologout (NMA-952)

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
+++ b/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
@@ -59,6 +59,7 @@ open class CheckPinDialog : DialogFragment() {
         @JvmStatic
         fun show(activity: FragmentActivity, requestCode: Int = 0, pinOnly: Boolean = false) {
             val checkPinDialog = CheckPinDialog()
+
             if (PinRetryController.getInstance().isLocked) {
                 checkPinDialog.showLockedAlert(activity)
             } else {

--- a/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
+++ b/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
@@ -216,14 +216,17 @@ open class CheckPinDialog : DialogFragment() {
         } ?: throw IllegalStateException("Invalid Activity")
     }
 
-    protected open fun FragmentActivity.initSharedModel(activity: FragmentActivity) {
-        sharedModel = ViewModelProvider(activity)[CheckPinSharedModel::class.java]
+    protected fun initLockScreenViewModel(activity: FragmentActivity) {
         lockScreenViewModel = ViewModelProvider(activity)[LockScreenViewModel::class.java]
-        log.info("viewModel = $lockScreenViewModel")
         lockScreenViewModel.activatingLockScreen.observe(viewLifecycleOwner) {
             sharedModel.onCancelCallback.call()
             dismiss()
         }
+    }
+
+    protected open fun FragmentActivity.initSharedModel(activity: FragmentActivity) {
+        sharedModel = ViewModelProvider(activity)[CheckPinSharedModel::class.java]
+        initLockScreenViewModel(activity)
     }
 
     protected fun setState(newState: State) {

--- a/wallet/src/de/schildbach/wallet/ui/DecryptSeedWithPinDialog.kt
+++ b/wallet/src/de/schildbach/wallet/ui/DecryptSeedWithPinDialog.kt
@@ -83,6 +83,7 @@ class DecryptSeedWithPinDialog : CheckPinDialog() {
 
     override fun FragmentActivity.initSharedModel(activity: FragmentActivity) {
         sharedModel = ViewModelProvider(activity)[DecryptSeedSharedModel::class.java]
+        initLockScreenViewModel(activity)
     }
 
     override fun onFingerprintSuccess(savedPass : String) {

--- a/wallet/src/de/schildbach/wallet/ui/LockScreenActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/LockScreenActivity.kt
@@ -64,7 +64,7 @@ open class LockScreenActivity : AppCompatActivity() {
     private val configuration = walletApplication.configuration
     private val autoLogout: AutoLogout = walletApplication.autoLogout
 
-    private lateinit var viewModel: LockScreenViewModel
+    protected lateinit var lockScreenViewModel: LockScreenViewModel
     private lateinit var checkPinViewModel: CheckPinViewModel
     private lateinit var enableFingerprintViewModel: EnableFingerprintDialog.SharedViewModel
     private var pinLength = configuration.pinLength
@@ -127,7 +127,7 @@ open class LockScreenActivity : AppCompatActivity() {
     }
 
     private val onLogoutListener = AutoLogout.OnLogoutListener {
-        viewModel.activatingLockScreen.call()
+        lockScreenViewModel.activatingLockScreen.call()
         setLockState(State.USE_DEFAULT)
     }
 
@@ -190,7 +190,7 @@ open class LockScreenActivity : AppCompatActivity() {
         autoLogout.setOnLogoutListener(onLogoutListener)
 
         if (!keepUnlocked && configuration.autoLogoutEnabled && (autoLogout.keepLockedUntilPinEntered || autoLogout.shouldLogout())) {
-            viewModel.activatingLockScreen.call()
+            lockScreenViewModel.activatingLockScreen.call()
             setLockState(State.USE_DEFAULT)
             autoLogout.setAppWentBackground(false)
             if (autoLogout.isTimerActive) {
@@ -257,7 +257,7 @@ open class LockScreenActivity : AppCompatActivity() {
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProvider(this)[LockScreenViewModel::class.java]
+        lockScreenViewModel = ViewModelProvider(this)[LockScreenViewModel::class.java]
         checkPinViewModel = ViewModelProvider(this)[CheckPinViewModel::class.java]
         checkPinViewModel.checkPinLiveData.observe(this, Observer {
             when (it.status) {

--- a/wallet/src/de/schildbach/wallet/ui/ViewSeedActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/ViewSeedActivity.kt
@@ -64,6 +64,10 @@ class ViewSeedActivity : BaseMenuActivity() {
         }
 
         setTitle(R.string.view_seed_title)
+
+        lockScreenViewModel.activatingLockScreen.observe(this) {
+            finish()
+        }
     }
 
     override fun onBackPressed() {


### PR DESCRIPTION
…logout

<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
