### PR TITLE
fix: dashpay sonatype repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,5 +25,6 @@ allprojects {
         mavenCentral()
         jcenter()
         maven { url 'https://jitpack.io' }
+        maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' }
     }
 }

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -9,13 +9,10 @@ ext {
 repositories {
     mavenLocal()
     mavenCentral()
-    maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' }
     maven {
         url 'https://maven.google.com/'
         name 'Google'
     }
-
-
 }
 
 dependencies {


### PR DESCRIPTION
## Issue being fixed or feature implemented
Building dashpay branch produces "Could not find org.dashj:dashj-core:0.18-SNAPSHOT." error.
Fixed by moving sonatype repository from wallet level to the allprojects scope since most modules are referencing dashj.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
