### PR TITLE
refactor: set application taskAffinity="" instead of each activity (NMA-997)

### DIFF
--- a/wallet/AndroidManifest.xml
+++ b/wallet/AndroidManifest.xml
@@ -60,12 +60,12 @@
         android:label="@string/app_name"
         android:largeHeap="true"
         android:theme="@style/My.Theme"
+        android:taskAffinity=""
         tools:ignore="LockedOrientationActivity">
 
         <activity
             android:name="de.schildbach.wallet.ui.OnboardingActivity"
             android:screenOrientation="portrait"
-            android:taskAffinity=""
             android:theme="@style/SplashActivity.Theme">
 
             <intent-filter>
@@ -96,7 +96,6 @@
             android:configChanges="keyboard|keyboardHidden"
             android:exported="true"
             android:label="@string/app_name_short"
-            android:taskAffinity=""
             android:screenOrientation="portrait"
             android:theme="@style/LockScreenActivity.Child.Theme"
             android:windowSoftInputMode="stateAlwaysHidden" />
@@ -124,7 +123,6 @@
             android:name="de.schildbach.wallet.ui.send.SendCoinsActivity"
             android:label="@string/pay_title"
             android:screenOrientation="portrait"
-            android:taskAffinity=""
             android:theme="@style/My.Theme.ChildActivity"
             tools:ignore="LockedOrientationActivity">
             <intent-filter android:label="@string/send_coins_activity_title">
@@ -205,7 +203,6 @@
             android:label="@string/app_name"
             android:noHistory="true"
             android:excludeFromRecents="true"
-            android:taskAffinity=""
             android:theme="@style/My.Theme.Transparent">
 
             <intent-filter>
@@ -224,7 +221,6 @@
             android:excludeFromRecents="true"
             android:label="@string/app_name"
             android:noHistory="true"
-            android:taskAffinity=""
             android:theme="@style/My.Theme.Transparent">
 
             <intent-filter android:label="@string/sweep_wallet_activity_title">
@@ -365,7 +361,6 @@
 
         <activity
             android:name="org.dash.wallet.integration.liquid.ui.LiquidAuthRedirectActivity"
-            android:taskAffinity=""
             android:excludeFromRecents="true"
             android:noHistory="true"
             android:theme="@style/My.Theme.ChildActivity">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
NMA-997

Documentation related to the Strandhogg v1 fix indicates that all activities or `application` need the `taskAffinity=""` value set.

If we do this, will some of our `magical` fixes to get around a new task being created with intents from other apps (web browsers, custom tabs, invites) still be necessary?

When this is merged into the `dashpay` branch, there may be other activities with `taskAffinity=""` that could be changed.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
