### PR TITLE
Github Actions fixes: github run_id instead of run_number and correct test group

### DIFF
--- a/.github/workflows/dashwallet.yml
+++ b/.github/workflows/dashwallet.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - name: Get build number from run id
       env:
-          run_num: ${{ github.run_number }}
+          run_num: ${{ github.run_id }}
       run: |
           echo "build_number=$((70000+$run_num))" >> $GITHUB_ENV
     
@@ -78,8 +78,8 @@ jobs:
       
     - name: TestNet Build and Firebase Distribution
       if: github.event_name == 'push'
-      run: bundle exec fastlane build_distribute flavor:"_testNet3" type:"release" store_pass:"${{ secrets.SIGNING_STORE_PASS }}" version_code:"${{ env.build_number }}" comment:"Up to date Dash Wallet TestNet build" app_id:"1:1039839682638:android:3202b16d460a1a88" test_group:"temp-test-group"
+      run: bundle exec fastlane build_distribute flavor:"_testNet3" type:"release" store_pass:"${{ secrets.SIGNING_STORE_PASS }}" version_code:"${{ env.build_number }}" comment:"Up to date Dash Wallet TestNet build" app_id:"1:1039839682638:android:3202b16d460a1a88" test_group:"qa"
       
     - name: Production Build and Firebase Distribution
       if: github.event_name == 'push'
-      run: bundle exec fastlane build_distribute flavor:"prod" type:"release" store_pass:"${{ secrets.SIGNING_STORE_PASS }}" version_code:"${{ env.build_number }}" comment:"Up to date Dash Wallet Production build" app_id:"1:1039839682638:android:989eecd6db36de6a" test_group:"temp-test-group"
+      run: bundle exec fastlane build_distribute flavor:"prod" type:"release" store_pass:"${{ secrets.SIGNING_STORE_PASS }}" version_code:"${{ env.build_number }}" comment:"Up to date Dash Wallet Production build" app_id:"1:1039839682638:android:989eecd6db36de6a" test_group:"qa"

--- a/.github/workflows/manual_distribution.yml
+++ b/.github/workflows/manual_distribution.yml
@@ -70,7 +70,7 @@ jobs:
           
     - name: Get build number from run id
       env:
-          run_num: ${{ github.run_number }}
+          run_num: ${{ github.run_id }}
       run: |
           echo "build_number=$(($base_build_number+$run_num))" >> $GITHUB_ENV
     
@@ -129,4 +129,4 @@ jobs:
       run: bundle exec fastlane test flavor:"${{ github.event.inputs.flavor }}" type:"${{ github.event.inputs.type }}" version_code:"${{ env.build_number }}" store_pass:"${{ secrets.SIGNING_STORE_PASS }}"
       
     - name: Build and Firebase Distribution
-      run: bundle exec fastlane build_distribute flavor:"${{ github.event.inputs.flavor }}" type:"${{ github.event.inputs.type }}" version_code:"${{ env.build_number }}" store_pass:"${{ secrets.SIGNING_STORE_PASS }}" comment:"${{ github.event.inputs.taskID }}" app_id:"${{ env.firebase_app_id }}" test_group:"temp-test-group"
+      run: bundle exec fastlane build_distribute flavor:"${{ github.event.inputs.flavor }}" type:"${{ github.event.inputs.type }}" version_code:"${{ env.build_number }}" store_pass:"${{ secrets.SIGNING_STORE_PASS }}" comment:"${{ github.event.inputs.taskID }}" app_id:"${{ env.firebase_app_id }}" test_group:"qa"


### PR DESCRIPTION
Changed run_number which is local to a workflow to run_id which is global to the repo. Changed test group to real QA group.
## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
https://github.com/dashevo/dash-wallet/pull/741

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
