### PR TITLE
Github Actions fix: reversing to run_number

### DIFF
--- a/.github/workflows/dashwallet.yml
+++ b/.github/workflows/dashwallet.yml
@@ -13,10 +13,8 @@ jobs:
 
     steps:
     - name: Get build number from run id
-      env:
-          run_num: ${{ github.run_id }}
       run: |
-          echo "build_number=$((70000+$run_num))" >> $GITHUB_ENV
+          echo "build_number=$((70000))" >> $GITHUB_ENV
     
     - uses: actions/checkout@v2
     - name: set up JDK 8

--- a/.github/workflows/manual_distribution.yml
+++ b/.github/workflows/manual_distribution.yml
@@ -70,7 +70,7 @@ jobs:
           
     - name: Get build number from run id
       env:
-          run_num: ${{ github.run_id }}
+          run_num: ${{ github.run_number }}
       run: |
           echo "build_number=$(($base_build_number+$run_num))" >> $GITHUB_ENV
     


### PR DESCRIPTION
## Issue being fixed or feature implemented
run_id isn't an incremental number, but just a unique random number, so we shouldn't use it. Changed back to run_id for manual workflow. For dash wallet workflow, we can leave base build number 70000 for all builds.

## Related PR's and Dependencies
https://github.com/dashevo/dash-wallet/pull/743
https://github.com/dashevo/dash-wallet/pull/741

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
