### PR TITLE
fix: keep payment flow unlocked if activated from Lock Screen (NMA-1011)

### DIFF
--- a/.github/workflows/manual_distribution.yml
+++ b/.github/workflows/manual_distribution.yml
@@ -39,7 +39,7 @@ jobs:
             },
             "schnapps": {
               "firebase_app_id": "1:1039839682638:android:12d2ad31cc39093cea631f"
-            },
+            }
           }
             
     - name: Map branch to build number offset

--- a/wallet/src/de/schildbach/wallet/ui/SendCoinsQrActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/SendCoinsQrActivity.java
@@ -80,9 +80,11 @@ public class SendCoinsQrActivity extends ShortcutComponentActivity {
             new StringInputParser(input, true) {
                 @Override
                 protected void handlePaymentIntent(final PaymentIntent paymentIntent) {
-                    SendCoinsInternalActivity.start(SendCoinsQrActivity.this, getIntent().getAction(), paymentIntent, false, true);
+                    boolean quickScan = isQuickScan();
+                    // if this is a quick scan, keepUnlock = true for SendCoinsInternalActivity
+                    SendCoinsInternalActivity.start(SendCoinsQrActivity.this, getIntent().getAction(), paymentIntent, false, quickScan);
 
-                    if (isQuickScan()) {
+                    if (quickScan) {
                         SendCoinsQrActivity.this.finish();
                     }
                 }

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsActivity.java
@@ -48,7 +48,12 @@ public class SendCoinsActivity extends AbstractBindServiceActivity {
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        getIntent().putExtra(LockScreenActivity.INTENT_EXTRA_KEEP_UNLOCKED, true);
+
+        // only set INTENT_EXTRA_KEEP_UNLOCKED if it is not yet set
+        // if this Activity is started by a dash: uri, then it will not be set
+        if (!getIntent().hasExtra(INTENT_EXTRA_KEEP_UNLOCKED)) {
+            getIntent().putExtra(INTENT_EXTRA_KEEP_UNLOCKED, true);
+        }
 
         SendCoinsActivityViewModel viewModel = ViewModelProviders.of(this).get(SendCoinsActivityViewModel.class);
         viewModel.getBasePaymentIntent().observe(this, new Observer<Resource<PaymentIntent>>() {

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsInternalActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsInternalActivity.java
@@ -69,10 +69,4 @@ public class SendCoinsInternalActivity extends SendCoinsActivity {
         }
         return getIntent().getBooleanExtra(INTENT_EXTRA_USER_AUTHORIZED, false);
     }
-
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        getIntent().putExtra(LockScreenActivity.INTENT_EXTRA_KEEP_UNLOCKED, false);
-    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
There are many ways to initiate a payment flow.

We found that from the Lock Screen, after pressing Scan to Pay and scanning a QR code, then the Lock Screen was displayed again.

In this particular payment flow, the Lock Screen should not be displayed.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
