### PR TITLE
Actions fix: build number for branches other than master

### DIFF
--- a/.github/workflows/manual_distribution.yml
+++ b/.github/workflows/manual_distribution.yml
@@ -39,20 +39,6 @@ jobs:
             },
             "schnapps": {
               "firebase_app_id": "1:1039839682638:android:12d2ad31cc39093cea631f"
-            },
-          }
-            
-    - name: Map branch to build number offset
-      uses: kanga333/variable-mapper@master
-      with:
-        key: "${{ github.ref }}"
-        map: |
-          {
-            "refs/heads/master": {
-              "base_build_number": "70000"
-            },
-            "refs/heads/dashpay": {
-              "base_build_number": "80000"
             }
           }
           
@@ -60,7 +46,7 @@ jobs:
       env:
           run_num: ${{ github.run_number }}
       run: |
-          echo "build_number=$(($base_build_number+$run_num))" >> $GITHUB_ENV
+          echo "build_number=$((70000+$run_num))" >> $GITHUB_ENV
     
     - uses: actions/checkout@v2    
     - name: set up JDK 8


### PR DESCRIPTION
## Issue being fixed or feature implemented
There is a problem with build number that doesn't get appended to base number (see latest wallet prod buld): we had a mapper that assignes 70000 or 80000 depending on current branch, but the mapper only check for `refs/heads/master` or `refs/heads/dashpay`, while we can run manual QA from any branch.

Those branches that were checked out from dashpay are usually fine because they start from `dashpay-`, but those that are checked out from master branch are getting wrong build number.

Solved by directly assigning a build number. This will cause a slight merge conflict which will have to be resolved, but `manual_distribution.xml` is already diverged for assigning different default flavor depending on branch, since that's the only way to do it.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
