### PR TITLE
[NMA-978] Advanced Security / View Recovery Phrase AutoLogout Issue

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/AdvancedSecurityActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/AdvancedSecurityActivity.kt
@@ -115,6 +115,10 @@ class AdvancedSecurityActivity : BaseMenuActivity() {
 
         updateView()
         setTitle(R.string.security_title)
+
+        lockScreenViewModel.activatingLockScreen.observe(this) {
+            finish()
+        }
     }
 
     private fun getSecurityLevel(): SecurityLevel {


### PR DESCRIPTION
## Issue being fixed or feature implemented
It seems like this issue was already fixed for view recovery phrase screen, but not for advanced security. I used the same code to keep it consistent.

## Related PR's and Dependencies
https://github.com/dashevo/dash-wallet/pull/706

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
