### PR TITLE
fix: enable the close button after a purchase (NMA-1014)

### DIFF
--- a/liquid-integration/src/main/java/org/dash/wallet/integration/liquid/ui/BuyDashWithCreditCardActivity.kt
+++ b/liquid-integration/src/main/java/org/dash/wallet/integration/liquid/ui/BuyDashWithCreditCardActivity.kt
@@ -125,6 +125,7 @@ class BuyDashWithCreditCardActivity : InteractionAwareActivity() {
     private var walletAddress: String? = null
     private var userAmount: String? = null
     private var isTransactionSuccessful = false
+    private var finishWithCloseButton = false
     private var lostConnection = false
 
     private var mPermissionRequest: PermissionRequest? = null
@@ -495,6 +496,7 @@ class BuyDashWithCreditCardActivity : InteractionAwareActivity() {
                                         viewBinding.closePane.visibility = View.VISIBLE
                                         viewBinding.btnOkay.setOnClickListener {
                                             setResult(Constants.RESULT_CODE_GO_HOME)
+                                            finishWithCloseButton = true
                                             onBackPressed()
                                         }
                                     }
@@ -587,7 +589,13 @@ class BuyDashWithCreditCardActivity : InteractionAwareActivity() {
 
     override fun onBackPressed() {
         when (widgetState) {
-            "success" -> analytics.logEvent(AnalyticsConstants.Liquid.WIDGET_PROCESSING_CLOSE_OVERLAY, bundleOf())
+            "success" -> {
+                if (finishWithCloseButton) {
+                    analytics.logEvent(AnalyticsConstants.Liquid.WIDGET_PROCESSING_CLOSE_OVERLAY, bundleOf())
+                } else {
+                    analytics.logEvent(AnalyticsConstants.Liquid.WIDGET_PROCESSING_CLOSE_TOP_LEFT, bundleOf())
+                }
+            }
             "quote_view" -> analytics.logEvent(AnalyticsConstants.Liquid.WIDGET_QUOTE_CLOSE, bundleOf())
             "verifying" -> analytics.logEvent(AnalyticsConstants.Liquid.WIDGET_PROCESSING_CLOSE_TOP_LEFT, bundleOf())
             else -> {}

--- a/liquid-integration/src/main/java/org/dash/wallet/integration/liquid/ui/BuyDashWithCreditCardActivity.kt
+++ b/liquid-integration/src/main/java/org/dash/wallet/integration/liquid/ui/BuyDashWithCreditCardActivity.kt
@@ -487,6 +487,7 @@ class BuyDashWithCreditCardActivity : InteractionAwareActivity() {
                                 "success" -> {
                                     log.info("liquid: buy dash transaction successful")
                                     onUserInteraction()
+                                    widgetState = "success"
                                     logProcessingDuration("success")
 
                                     if (!isTransactionSuccessful) {
@@ -586,6 +587,7 @@ class BuyDashWithCreditCardActivity : InteractionAwareActivity() {
 
     override fun onBackPressed() {
         when (widgetState) {
+            "success" -> analytics.logEvent(AnalyticsConstants.Liquid.WIDGET_PROCESSING_CLOSE_OVERLAY, bundleOf())
             "quote_view" -> analytics.logEvent(AnalyticsConstants.Liquid.WIDGET_QUOTE_CLOSE, bundleOf())
             "verifying" -> analytics.logEvent(AnalyticsConstants.Liquid.WIDGET_PROCESSING_CLOSE_TOP_LEFT, bundleOf())
             else -> {}

--- a/liquid-integration/src/main/java/org/dash/wallet/integration/liquid/ui/BuyDashWithCreditCardActivity.kt
+++ b/liquid-integration/src/main/java/org/dash/wallet/integration/liquid/ui/BuyDashWithCreditCardActivity.kt
@@ -177,8 +177,7 @@ class BuyDashWithCreditCardActivity : InteractionAwareActivity() {
     private fun loadWebView() {
 
         log.info("liquid: loading webview")
-        val toolbar = findViewById<Toolbar>(R.id.toolbar)
-        setSupportActionBar(toolbar)
+        setSupportActionBar(viewBinding.toolbar)
 
         val actionBar = supportActionBar
         actionBar?.apply {
@@ -290,8 +289,8 @@ class BuyDashWithCreditCardActivity : InteractionAwareActivity() {
         webview.loadUrl(LiquidConstants.BUY_WITH_CREDIT_CARD_URL)
 
         //don't show the (i) icon
-        findViewById<View>(R.id.ivInfo).isVisible = false
-        findViewById<View>(R.id.ivInfo).setOnClickListener {
+        viewBinding.ivInfo.isVisible = false
+        viewBinding.ivInfo.setOnClickListener {
             CountrySupportDialog(this, true).show()
         }
     }
@@ -492,8 +491,8 @@ class BuyDashWithCreditCardActivity : InteractionAwareActivity() {
 
                                     if (!isTransactionSuccessful) {
                                         isTransactionSuccessful = true
-                                        findViewById<View>(R.id.closePane).visibility = View.VISIBLE
-                                        findViewById<View>(R.id.btnOkay).setOnClickListener {
+                                        viewBinding.closePane.visibility = View.VISIBLE
+                                        viewBinding.btnOkay.setOnClickListener {
                                             setResult(Constants.RESULT_CODE_GO_HOME)
                                             onBackPressed()
                                         }

--- a/liquid-integration/src/main/res/layout/activity_webview_quick_exchange.xml
+++ b/liquid-integration/src/main/res/layout/activity_webview_quick_exchange.xml
@@ -33,7 +33,9 @@
     <ViewSwitcher
         android:id="@+id/view_switcher"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        tools:visibility="visible"
         android:animateFirstView="false"
         android:measureAllChildren="true">
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
Show the close button again after making a purchase from Liquid.

remove the use of findViewById since we are using view bindings.
## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [X] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
