### PR TITLE
fix: build sample-integration-android with SDK 30

### DIFF
--- a/sample-integration-android/build.gradle
+++ b/sample-integration-android/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 'android-15'
+    compileSdkVersion 30
 
     lintOptions { abortOnError false }
 
@@ -37,6 +37,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 23
+        targetSdkVersion 30
         multiDexEnabled true
     }
     compileOptions {


### PR DESCRIPTION
* this prevents a build error with Gradle 6.7.1

<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
* Enable Sample Integration app builds
* Resolve CI/Manual Distribution build failures
## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
