### PR TITLE
feat: copy address on button click then do faucet link - NMA-1081

### DIFF
--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -499,7 +499,7 @@
     <string name="explore_test_subtitle">Test Dash doesn’t have any value in the real world but you can send and receive it with other DashPay Alpha users.</string>
     <string name="explore_test_dash_title">How do I get Test Dash?</string>
     <string name="explore_test_dash_text_1">Test Dash is free and can be obtained from what is called a faucet.</string>
-    <string name="explore_test_dash_text_2">Copy an address from the Receive screen of your wallet and click on the button bellow to get your Dash.</string>
+    <string name="explore_test_dash_text_2">Click on the button below to copy a Dash address from this wallet so you can get your test Dash..</string>
     <string name="explore_get_test_dash">Get Test Dash</string>
 
     <string name="notifications_title">Notifications</string>

--- a/wallet/src/de/schildbach/wallet/ui/explore/ExploreTestNetFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/explore/ExploreTestNetFragment.kt
@@ -1,11 +1,15 @@
 package de.schildbach.wallet.ui.explore
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import dagger.hilt.android.AndroidEntryPoint
 import de.schildbach.wallet.Constants
+import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet.ui.dashpay.BottomNavFragment
 import de.schildbach.wallet_test.R
 import de.schildbach.wallet_test.databinding.FragmentExploreTestnetBinding
@@ -27,6 +31,12 @@ class ExploreTestNetFragment : BottomNavFragment(R.layout.fragment_explore_testn
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.getDashBtn.setOnClickListener {
+            val receiveAddress = WalletApplication.getInstance().freshReceiveAddress()
+            val clipboardManager =
+                requireActivity().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+
+            clipboardManager.setPrimaryClip(ClipData.newPlainText("Bitcoin address", receiveAddress.toString()))
+
             val faucetIntent = Intent(
                 Intent.ACTION_VIEW,
                 Uri.parse(Constants.TESTNET_FAUCET_URL)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
Change behavior.  Copy next Address to clipboard before activating faucet link.
## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
