### PR TITLE
Bugfix:  dashpay android 6 invite creation failure (NMA-1096)

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/dashpay/work/SendInviteWorker.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/work/SendInviteWorker.kt
@@ -126,7 +126,7 @@ class SendInviteWorker @AssistedInject constructor(
         // in each suspend method that uses the dashj Context
         org.bitcoinj.core.Context.propagate(wallet.context)
         val username = dashPayProfile.username
-        val avatarUrlEncoded = URLEncoder.encode(dashPayProfile.avatarUrl, StandardCharsets.UTF_8.toString())
+        val avatarUrlEncoded = URLEncoder.encode(dashPayProfile.avatarUrl, StandardCharsets.UTF_8.displayName())
         return FirebaseDynamicLinks.getInstance()
                 .createDynamicLink().apply {
                     link = InvitationLinkData.create(username, dashPayProfile.displayName, avatarUrlEncoded, cftx, aesKeyParameter).link

--- a/wallet/src/de/schildbach/wallet/ui/dashpay/work/SendInviteWorker.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/work/SendInviteWorker.kt
@@ -141,7 +141,7 @@ class SendInviteWorker @AssistedInject constructor(
                 .setSocialMetaTagParameters(DynamicLink.SocialMetaTagParameters.Builder().apply {
                     title = applicationContext.getString(R.string.invitation_preview_title)
                     val nameLabel = dashPayProfile.nameLabel
-                    val nameLabelEncoded = URLEncoder.encode(nameLabel, StandardCharsets.UTF_8.toString())
+                    val nameLabelEncoded = URLEncoder.encode(nameLabel, StandardCharsets.UTF_8.displayName())
                     imageUrl = Uri.parse("https://invitations.dashpay.io/fun/invite-preview?display-name=$nameLabelEncoded&avatar-url=$avatarUrlEncoded")
                     description = applicationContext.getString(R.string.invitation_preview_message, nameLabel)
                 }.build())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

On Android 6, `StandardCharsets.UTF_8.toString()` is rendered as "java.nio.charset.CharsetICU[UTF-8]" which results in this crash:
```
Non-fatal Exception: java.nio.charset.IllegalCharsetNameException
java.nio.charset.CharsetICU[UTF-8]

java.nio.charset.Charset.checkCharsetName (Charset.java:201)
java.nio.charset.Charset.forName (Charset.java:295)
java.net.URLEncoder.encode (URLEncoder.java:57)
de.schildbach.wallet.ui.dashpay.work.SendInviteWorker.createDynamicLink (SendInviteWorker.java:126)
de.schildbach.wallet.ui.dashpay.work.SendInviteWorker.doWorkWithBaseProgress (SendInviteWorker.java:103) 
```
## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
