### PR TITLE
fix: migrating from actions/setup-ruby to ruby/setup-ruby

### DIFF
--- a/.github/workflows/dashwallet.yml
+++ b/.github/workflows/dashwallet.yml
@@ -34,9 +34,9 @@ jobs:
       run: chmod +x gradlew
       
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0.2'
+        ruby-version: '3.0.3'
         
     - name: Generate cache key
       run: bash ./checksum.sh checksum.txt

--- a/.github/workflows/manual_distribution.yml
+++ b/.github/workflows/manual_distribution.yml
@@ -66,9 +66,9 @@ jobs:
       run: chmod +x gradlew
       
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0.2'
+        ruby-version: '3.0.3'
         
     - name: Generate cache key
       run: bash ./checksum.sh checksum.txt


### PR DESCRIPTION
Fixing ruby action in github actions pipelines.

## Issue being fixed or feature implemented
`actions/setup-ruby` isn't maintained anymore and needs to be replaced with `ruby/setup-ruby`.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
