### PR TITLE
fix: remove duplicate background color and request title set up for FancyA…

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/ui/FancyAlertDialog.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/FancyAlertDialog.kt
@@ -92,11 +92,6 @@ class FancyAlertDialog : DialogFragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        // Set transparent background and no title
-        dialog?.window?.apply {
-            setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-            requestFeature(Window.FEATURE_NO_TITLE)
-        }
         return inflater.inflate(R.layout.fancy_alert_dialog, container)
     }
 


### PR DESCRIPTION
We have an AndroidRuntimeException on `FancyAlertDialog` when working on the `Buy/Sell` flow. This work fixes it
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
Remove  for setting up  background and requestTitle parameters on `FancyAlertDialog` before view get's created
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
