### PR TITLE
fix: AndroidRuntimeException: requestFeature() must be called before adding content

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/ui/FancyAlertDialog.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/FancyAlertDialog.kt
@@ -161,8 +161,6 @@ class FancyAlertDialog : DialogFragment() {
         dialog?.apply {
             window?.apply {
                 setLayout(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
-                setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-                requestFeature(Window.FEATURE_NO_TITLE)
                 callback = UserInteractionAwareCallback(this.callback, requireActivity())
             }
             if (type == Type.PROGRESS) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
I tested this and it fixed this:
```
    android.util.AndroidRuntimeException: requestFeature() must be called before adding content
        at com.android.internal.policy.PhoneWindow.requestFeature(PhoneWindow.java:344)
        at org.dash.wallet.common.ui.FancyAlertDialog.onStart(FancyAlertDialog.kt:160)
```

In my testing ,https://github.com/dashevo/dash-wallet/pull/831 didn't eliminate the crash.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
