### PR TITLE
fix: remove automatic display of merchant info screen in ATM search

### DIFF
--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/SearchFragment.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/SearchFragment.kt
@@ -117,8 +117,7 @@ class SearchFragment : Fragment(R.layout.fragment_search) {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        if (!configuration.hasExploreDashInfoScreenBeenShown()) {
+        if (!configuration.hasExploreDashInfoScreenBeenShown() && args.type == ExploreTopic.Merchants) {
             safeNavigate(SearchFragmentDirections.exploreToInfo())
             configuration.setHasExploreDashInfoScreenBeenShown(true)
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
The `merchant info screen` should be automatically displayed for the first time only when we enter the Merchant search
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
