### PR TITLE
[NMA-1115] (Explore Dash) Possible fix for sync worker issues

### DIFF
--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -43,9 +43,11 @@ import android.widget.Toast;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+import androidx.work.BackoffPolicy;
 import androidx.work.ExistingWorkPolicy;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
+import androidx.work.WorkRequest;
 
 import com.google.common.base.Stopwatch;
 import com.jakewharton.processphoenix.ProcessPhoenix;
@@ -191,6 +193,11 @@ public class WalletApplication extends BaseWalletApplication implements AutoLogo
 
         OneTimeWorkRequest syncDataWorkRequest =
                 new OneTimeWorkRequest.Builder(ExploreSyncWorker.class)
+                        .setBackoffCriteria(
+                                BackoffPolicy.EXPONENTIAL,
+                                WorkRequest.DEFAULT_BACKOFF_DELAY_MILLIS,
+                                TimeUnit.MILLISECONDS
+                        )
                         .build();
 
         WorkManager.getInstance(this.getApplicationContext()).enqueueUniqueWork(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->
Sync worker fails to run sometimes with a firebase error “client is offline” even though the connection is present.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
It's not 100% clear what is the problem, but it might be related to the usage of `await()` method from the `kotlinx-coroutines-play-services`, even though this issue was apparently [fixed a while ago](https://github.com/firebase/firebase-android-sdk/issues/2385). I moved all of the firebase data fetching methods from `await()` back to `addListenerForSingleValueEvent` just in case this is the problem.

Another possibility is that this is simply due to connection problems, hence I've added an exponential backoff retrying policy.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
