### PR TITLE
[NMA-1105] Currency selector problems

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/EnterAmountFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/EnterAmountFragment.kt
@@ -36,14 +36,13 @@ import org.bitcoinj.utils.MonetaryFormat
 import org.dash.wallet.common.services.analytics.AnalyticsConstants
 import org.dash.wallet.common.services.analytics.FirebaseAnalyticsServiceImpl
 import org.dash.wallet.common.util.GenericUtils
-import de.schildbach.wallet.ui.ExchangeRatesFragment.ARG_SHOW_AS_DIALOG
 import de.schildbach.wallet.rates.ExchangeRate
 import java.util.*
 import android.content.Intent
 import android.app.Activity
 import android.content.Context
 import de.schildbach.wallet.WalletApplication
-import de.schildbach.wallet.ui.ExchangeRatesFragment.BUNDLE_EXCHANGE_RATE
+import de.schildbach.wallet.ui.ExchangeRatesFragment.*
 import org.dash.wallet.common.Configuration
 import org.dash.wallet.common.util.FiatAmountFormat
 
@@ -178,12 +177,16 @@ class EnterAmountFragment : Fragment() {
         input_select_currency_toggle.setOnClickListener {
             val intent = Intent(activity, ExchangeRatesActivity::class.java)
             intent.putExtra(ARG_SHOW_AS_DIALOG, true)
+            val currencyCode = sharedViewModel.exchangeRate?.fiat?.currencyCode ?: configuration.exchangeCurrencyCode
+            intent.putExtra(ARG_CURRENCY_CODE, currencyCode)
             startActivityForResult(intent, RC_FIAT_CURRENCY_SELECTED)
         }
 
         calc_select_currency_toggle.setOnClickListener {
             val intent = Intent(activity, ExchangeRatesActivity::class.java)
             intent.putExtra(ARG_SHOW_AS_DIALOG, true)
+            val currencyCode = sharedViewModel.exchangeRate?.fiat?.currencyCode ?: configuration.exchangeCurrencyCode
+            intent.putExtra(ARG_CURRENCY_CODE, currencyCode)
             startActivityForResult(intent, RC_FIAT_CURRENCY_SELECTED)
         }
     }

--- a/wallet/src/de/schildbach/wallet/ui/ExchangeRatesActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/ExchangeRatesActivity.java
@@ -34,8 +34,9 @@ public class ExchangeRatesActivity extends AbstractBindServiceActivity {
         setContentView(R.layout.exchange_rates_content);
 
         if(savedInstanceState == null) {
+            String currencyCode = getIntent().getStringExtra(ExchangeRatesFragment.ARG_CURRENCY_CODE);
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.container, ExchangeRatesFragment.newInstance())
+                    .replace(R.id.container, ExchangeRatesFragment.newInstance(currencyCode))
                     .commitNow();
         }
     }

--- a/wallet/src/de/schildbach/wallet/ui/ExchangeRatesFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/ExchangeRatesFragment.java
@@ -83,6 +83,7 @@ public final class ExchangeRatesFragment extends DialogFragment implements OnSha
     private ConstraintLayout viewContainer;
     private Group settingsGroup, sendPaymentGroup;
     public static final String ARG_SHOW_AS_DIALOG = "ARG_SHOW_AS_DIALOG";
+    public static final String ARG_CURRENCY_CODE = "ARG_CURRENCY_CODE";
     private boolean showAsDialog;
     public static final String BUNDLE_EXCHANGE_RATE = "BUNDLE_EXCHANGE_RATE";
     @Override
@@ -94,37 +95,32 @@ public final class ExchangeRatesFragment extends DialogFragment implements OnSha
         this.wallet = application.getWallet();
     }
 
-    public static ExchangeRatesFragment newInstance(boolean showAsDialog) {
+    public static ExchangeRatesFragment newInstance(boolean showAsDialog, String selectedCurrency) {
         ExchangeRatesFragment fragment = new ExchangeRatesFragment();
         Bundle args = new Bundle();
         args.putBoolean(ARG_SHOW_AS_DIALOG, showAsDialog);
+        args.putString(ARG_CURRENCY_CODE, selectedCurrency);
         fragment.setArguments(args);
         return fragment;
     }
 
-    public static ExchangeRatesFragment newInstance() {
-        return newInstance(true);
+    public static ExchangeRatesFragment newInstance(String selectedCurrency) {
+        return newInstance(true, selectedCurrency);
     }
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        showAsDialog = getActivity().getIntent().getBooleanExtra(ARG_SHOW_AS_DIALOG, false);
+        showAsDialog = requireActivity().getIntent().getBooleanExtra(ARG_SHOW_AS_DIALOG, false);
         adapter = new ExchangeRatesAdapter(activity, config, wallet, new ArrayList<>(), this, this,showAsDialog);
         adapter.setRateBase(config.getBtcBase());
-        if (showAsDialog){
-            if (config.isDefaultFiatCurrencyChanged()) {
-                adapter.setDefaultCurrency(config.getExchangeCurrencyCode());
-                config.setDefaultFiatCurrencyChanged(false);
-            } else if (config.isCurrentFiatCurrencyChanged()) {
-                adapter.setDefaultCurrency(config.getSendPaymentExchangeCurrencyCode());
-                config.setCurrentFiatCurrencyChanged(false);
-            } else {
-                adapter.setDefaultCurrency(config.getExchangeCurrencyCode());
-            }
-        } else {
-            adapter.setDefaultCurrency(config.getExchangeCurrencyCode());
+        String currencyCode = requireActivity().getIntent().getStringExtra(ARG_CURRENCY_CODE);
+
+        if (Strings.isNullOrEmpty(currencyCode)) {
+            currencyCode = config.getExchangeCurrencyCode();
         }
+
+        adapter.setDefaultCurrency(currencyCode);
     }
 
     @Override

--- a/wallet/src/de/schildbach/wallet/ui/SettingsActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SettingsActivity.kt
@@ -25,10 +25,9 @@ import kotlinx.android.synthetic.main.activity_settings.*
 import org.dash.wallet.common.services.analytics.AnalyticsConstants
 import org.dash.wallet.common.services.analytics.FirebaseAnalyticsServiceImpl
 import org.slf4j.LoggerFactory
-import de.schildbach.wallet.ui.ExchangeRatesFragment.ARG_SHOW_AS_DIALOG
-import de.schildbach.wallet.ui.ExchangeRatesFragment.BUNDLE_EXCHANGE_RATE
 import android.app.Activity
 import de.schildbach.wallet.rates.ExchangeRate
+import de.schildbach.wallet.ui.ExchangeRatesFragment.*
 
 
 class SettingsActivity : BaseMenuActivity() {
@@ -52,6 +51,7 @@ class SettingsActivity : BaseMenuActivity() {
             analytics.logEvent(AnalyticsConstants.Settings.LOCAL_CURRENCY, bundleOf())
             val intent = Intent(this, ExchangeRatesActivity::class.java)
             intent.putExtra(ARG_SHOW_AS_DIALOG, false)
+            intent.putExtra(ARG_CURRENCY_CODE, configuration.exchangeCurrencyCode)
             startActivityForResult(intent, RC_DEFAULT_FIAT_CURRENCY_SELECTED)
         }
         rescan_blockchain.setOnClickListener { resetBlockchain() }


### PR DESCRIPTION
After making a payment with non-default currency, opening the currency selector again shows the wrong currency.

## Issue being fixed or feature implemented
The way I see it, the problem here is that we have a bunch of code in the `ExchangeRatesFragment` to decide which currency to show as selected. Because this code is independent of the one in the Enter Amount screen, it can get unsynchronized and we will have different currencies.

To prevent this problem from occurring again, we should move the responsibility of deciding selected currency to the caller of `ExchangeRatesFragment`, it itself should not make this decision unless no currency is specified. This way, whichever currency the caller has as default, `ExchangeRatesFragment` will have as selected.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
