### PR TITLE
[NMA-1123] Bugfix: lockscreen viewmodel crash

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/ui/FancyAlertDialog.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/FancyAlertDialog.kt
@@ -30,14 +30,14 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.activityViewModels
 import kotlinx.android.synthetic.main.fancy_alert_dialog.*
 import org.dash.wallet.common.R
 import org.dash.wallet.common.UserInteractionAwareCallback
 
 class FancyAlertDialog : DialogFragment() {
-    private lateinit var lockScreenViewModel: LockScreenViewModel
-    private lateinit var sharedViewModel: FancyAlertDialogViewModel
+    private val lockScreenViewModel by activityViewModels<LockScreenViewModel>()
+    private val sharedViewModel by activityViewModels<FancyAlertDialogViewModel>()
 
     enum class Type {
         INFO,
@@ -102,7 +102,6 @@ class FancyAlertDialog : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initViewModels()
         setOrHideIfEmpty(title, "title")
         setOrHideIfEmpty(message, "message")
         setOrHideIfEmpty(image, "image")
@@ -168,10 +167,5 @@ class FancyAlertDialog : DialogFragment() {
                 setCanceledOnTouchOutside(false)
             }
         }
-    }
-
-    private fun initViewModels() {
-        lockScreenViewModel = ViewModelProvider(this)[LockScreenViewModel::class.java]
-        sharedViewModel = ViewModelProvider(this)[FancyAlertDialogViewModel::class.java]
     }
 }

--- a/wallet/src/de/schildbach/wallet/ui/FancyListFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/FancyListFragment.java
@@ -46,7 +46,7 @@ public class FancyListFragment extends ListFragment {
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        lockScreenViewModel = new ViewModelProvider(this).get(LockScreenViewModel.class);
+        lockScreenViewModel = new ViewModelProvider(requireActivity()).get(LockScreenViewModel.class);
         lockScreenViewModel.getActivatingLockScreen().observe(this, unused -> alertDialog.dismiss());
     }
 

--- a/wallet/src/de/schildbach/wallet/ui/LockScreenActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/LockScreenActivity.kt
@@ -271,7 +271,6 @@ open class LockScreenActivity : SecureActivity() {
     }
 
     private fun initViewModel() {
-        //lockScreenViewModel = ViewModelProvider(this)[LockScreenViewModel::class.java]
         checkPinViewModel = ViewModelProvider(this)[CheckPinViewModel::class.java]
         checkPinViewModel.checkPinLiveData.observe(this, Observer {
             when (it.status) {


### PR DESCRIPTION
There is a crash in `LockScreenActivity.getLockScreenViewModel` which is related to Hilt:
```
Fatal Exception: java.lang.IllegalArgumentException
SavedStateProvider with the given key is already registered
androidx.savedstate.SavedStateRegistry.registerSavedStateProvider (SavedStateRegistry.java:111)
androidx.lifecycle.AbstractSavedStateViewModelFactory.create (AbstractSavedStateViewModelFactory.java:84)
dagger.hilt.android.internal.lifecycle.HiltViewModelFactory.create (HiltViewModelFactory.java:109)
```

This is probably happening because in the FancyAlertDialog, `LockScreenViewModel` is initialized with fragment as an owner instead of an activity.

## Issue being fixed or feature implemented
Replaced initializations with activity as owner.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
