### PR TITLE
[NMA-1111] Enter Amount fixes

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/ui/enter_amount/AmountView.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/enter_amount/AmountView.kt
@@ -74,14 +74,11 @@ class AmountView(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
                 updateDashSymbols()
 
                 val monetary = if (value) dashAmount else fiatAmount
-                input = if (monetary.value == 0L) {
-                    "0"
-                } else {
-                    if (value) {
-                        dashFormat.format(dashAmount)
-                    } else {
-                        fiatFormat.format(fiatAmount)
-                    }.toString()
+                input = when {
+                    monetary.value == 0L -> "0"
+                    value -> dashFormat.format(dashAmount).toString()
+                    else -> fiatFormat.minDecimals(0)
+                        .optionalDecimals(0,2).format(fiatAmount).toString()
                 }
             }
         }

--- a/integrations/coinbase-integration/src/main/java/org/dash/wallet/integration/coinbase_integration/ui/CoinbaseBuyDashFragment.kt
+++ b/integrations/coinbase-integration/src/main/java/org/dash/wallet/integration/coinbase_integration/ui/CoinbaseBuyDashFragment.kt
@@ -145,7 +145,8 @@ class CoinbaseBuyDashFragment: Fragment(R.layout.fragment_coinbase_buy_dash) {
                     paymentMethodType = type
                 )
             }
-        binding.paymentMethodPicker.paymentMethods = paymentMethods
+//        binding.paymentMethodPicker.paymentMethods = paymentMethods // TODO: change to this to see the picker
+        binding.paymentMethodPicker.paymentMethods = listOf(paymentMethods[1])
     }
 
     private fun splitNameAndAccount(nameAccount: String?): Pair<String, String> {


### PR DESCRIPTION
Toggling between dash and fiat causes input to have ".00" ending which prevents further input.
Another issue I've noticed is that when toggling, dash amount sometimes gets small fractions added or substructed.

## Issue being fixed or feature implemented
- Allow formatting input without a fractional part if it's not needed.
- Since we're anchoring to Dash when toggling between dash and fiat, I changed the logic to keep dash amount static instead of calculating it from the fiat input.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
