### PR TITLE
[NMA-1100] the local currency is not changed in the first time after installation

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/SettingsActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SettingsActivity.kt
@@ -93,8 +93,8 @@ class SettingsActivity : BaseMenuActivity() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if(resultCode == Activity.RESULT_OK && requestCode == RC_DEFAULT_FIAT_CURRENCY_SELECTED){
             val exchangeRate: ExchangeRate? = data?.getParcelableExtra(BUNDLE_EXCHANGE_RATE)
-            local_currency_symbol.text = if(exchangeRate != null) exchangeRate.currencyCode else
-                WalletApplication.getInstance().configuration.exchangeCurrencyCode
+            local_currency_symbol.text = exchangeRate?.currencyCode ?: configuration.exchangeCurrencyCode
+            configuration.exchangeCurrencyCodeDetected = true
         } else {
             super.onActivityResult(requestCode, resultCode, data)
         }


### PR DESCRIPTION
If a user in the US tries to change the default currency immediately after the installation, it will get reset back to USD after exiting the settings. This happens because `onResume` method is called in `MainActivity` and it triggers country detection again (this only happens in DashPay for some reason).

## Issue being fixed or feature implemented
`detectUserCountry` will not run if `exchangeCurrencyCodeDetected` is set. This property is used to detect unintended changes in the currency and show a dialog asking which one to keep. We can set it preemptively after the user changed the default currency, assuming that if it's changed explicitly, we don't need to confirm it with a dialog.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
