### PR TITLE
[NMA-1138] (Explore Dash) Fix: All tab ordering

### DIFF
--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/ExploreDataSource.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/ExploreDataSource.kt
@@ -159,12 +159,14 @@ open class MerchantAtmDataSource @Inject constructor(
                 // or filter is All, we search everything and filter by territory
                 val types = listOf(MerchantType.PHYSICAL, MerchantType.ONLINE, MerchantType.BOTH)
                 val onlineOrder = if (onlineFirst) 0 else 2
+                val physicalOrder = if (onlineFirst) 2 else 1
 
                 if (query.isNotBlank()) {
-                    merchantDao.pagingSearchByTerritory(sanitizeQuery(query), territory,
-                        types, paymentMethod, sortByDistance, userLat, userLng, onlineOrder)
+                    merchantDao.pagingSearchByTerritory(sanitizeQuery(query), territory, types,
+                        paymentMethod, sortByDistance, userLat, userLng, onlineOrder, physicalOrder)
                 } else {
-                    merchantDao.pagingGetByTerritory(territory, types, paymentMethod, sortByDistance, userLat, userLng, onlineOrder)
+                    merchantDao.pagingGetByTerritory(territory, types,
+                        paymentMethod, sortByDistance, userLat, userLng, onlineOrder, physicalOrder)
                 }
             }
         }

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/MerchantDao.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/MerchantDao.kt
@@ -168,7 +168,7 @@ interface MerchantDao : BaseDao<Merchant> {
             CASE type
                 WHEN "online"   THEN :onlineOrder
                 WHEN "both"     THEN 1
-                WHEN "physical" THEN 2 - :onlineOrder
+                WHEN "physical" THEN :physicalOrder
             END,
             CASE WHEN :sortByDistance = 1 THEN (latitude - :anchorLat)*(latitude - :anchorLat) + (longitude - :anchorLng)*(longitude - :anchorLng) END ASC,
             CASE WHEN :sortByDistance = 0 THEN merchant.name END COLLATE NOCASE ASC
@@ -180,7 +180,8 @@ interface MerchantDao : BaseDao<Merchant> {
         sortByDistance: Boolean,
         anchorLat: Double,
         anchorLng: Double,
-        onlineOrder: Int
+        onlineOrder: Int,
+        physicalOrder: Int
     ): PagingSource<Int, MerchantInfo>
 
     @Query("""
@@ -211,7 +212,7 @@ interface MerchantDao : BaseDao<Merchant> {
             CASE type
                 WHEN "online"   THEN :onlineOrder
                 WHEN "both"     THEN 1
-                WHEN "physical" THEN 2 - :onlineOrder
+                WHEN "physical" THEN :physicalOrder
             END,
             CASE WHEN :sortByDistance = 1 THEN (latitude - :anchorLat)*(latitude - :anchorLat) + (longitude - :anchorLng)*(longitude - :anchorLng) END ASC,
             CASE WHEN :sortByDistance = 0 THEN merchant.name END COLLATE NOCASE ASC
@@ -224,7 +225,8 @@ interface MerchantDao : BaseDao<Merchant> {
         sortByDistance: Boolean,
         anchorLat: Double,
         anchorLng: Double,
-        onlineOrder: Int
+        onlineOrder: Int,
+        physicalOrder: Int
     ): PagingSource<Int, MerchantInfo>
 
     @Query("""

--- a/features/exploredash/src/test/java/org/dash/wallet/features/exploredash/MerchantAtmDataSourceTest.kt
+++ b/features/exploredash/src/test/java/org/dash/wallet/features/exploredash/MerchantAtmDataSourceTest.kt
@@ -45,11 +45,11 @@ class MerchantDaoTest {
     private val atmDaoMock = mock<AtmDao>()
     private val merchantDaoMock = mock<MerchantDao> {
         on { pagingGetGrouped(any(), any()) } doReturn TestPagingSource()
-        on { pagingGetByTerritory(any(), any(), any(), any(), any(), any(), any()) } doReturn TestPagingSource()
+        on { pagingGetByTerritory(any(), any(), any(), any(), any(), any(), any(), any()) } doReturn TestPagingSource()
         on { pagingGetByCoordinates(any(), any(), any(), any(), any(), any(), any(), any(), any()) } doReturn TestPagingSource()
 
         on { pagingSearchGrouped(any(), any(), any()) } doReturn TestPagingSource()
-        on { pagingSearchByTerritory(any(), any(), any(), any(), any(), any(), any(), any()) } doReturn TestPagingSource()
+        on { pagingSearchByTerritory(any(), any(), any(), any(), any(), any(), any(), any(), any()) } doReturn TestPagingSource()
         on { pagingSearchByCoordinates(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } doReturn TestPagingSource()
     }
     private val dataSource = MerchantAtmDataSource(merchantDaoMock, atmDaoMock)
@@ -125,7 +125,7 @@ class MerchantDaoTest {
             bounds, false, 0.0, 0.0, false)
 
         verify(merchantDaoMock).pagingGetByTerritory(territory, requiredAllTypes, "",
-            false, 0.0, 0.0, 2)
+            false, 0.0, 0.0, 2, 1)
         verifyNoMoreInteractions(merchantDaoMock)
 
         // --- Physical type with bounds, query and territory should call pagingSearchByTerritory method ---
@@ -137,7 +137,7 @@ class MerchantDaoTest {
 
         verify(dataSourceSpy).sanitizeQuery(query)
         verify(merchantDaoMock).pagingSearchByTerritory(sanitizedQuery, territory, requiredAllTypes,
-            "", false, 0.0, 0.0, 2)
+            "", false, 0.0, 0.0, 2, 1)
         verifyNoMoreInteractions(merchantDaoMock)
     }
 
@@ -158,7 +158,7 @@ class MerchantDaoTest {
             GeoBounds.noBounds, false, 0.0, 0.0, false)
 
         verify(merchantDaoMock).pagingGetByTerritory("", requiredAllTypes, "",
-            false, 0.0, 0.0, 2)
+            false, 0.0, 0.0, 2,1)
         verifyNoMoreInteractions(merchantDaoMock)
 
         // --- All type with query should call pagingGetByTerritory method ---
@@ -170,7 +170,7 @@ class MerchantDaoTest {
 
         verify(dataSourceSpy).sanitizeQuery(query)
         verify(merchantDaoMock).pagingSearchByTerritory(sanitizedQuery, "", requiredAllTypes,
-            "", false, 0.0, 0.0, 2)
+            "", false, 0.0, 0.0, 2, 1)
         verifyNoMoreInteractions(merchantDaoMock)
     }
 }


### PR DESCRIPTION
Merchants are sorted Physical -> Both -> Online in the All tab when location is enabled, while Physical and Both should be in the same group. This is a side effect of sorting Online -> Both -> Physical for the case when location is disabled.

## Issue being fixed or feature implemented
Fixed by explicitly specifying the sort order for the Physical merchants.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
