### PR TITLE
[NMA-1145] (Explore Dash) Clearing results on switching filter tab

### DIFF
--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ExploreViewModel.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ExploreViewModel.kt
@@ -199,6 +199,7 @@ class ExploreViewModel @Inject constructor(
                     _selectedRadiusOption.flatMapLatest { selectedRadius ->
                         _selectedTerritory.flatMapLatest { territory ->
                             _filterMode.flatMapLatest { mode ->
+                                clearSearchResults()
                                 _searchBounds
                                     .filterNotNull()
                                     .filter { screenState.value == ScreenState.SearchResults }
@@ -468,8 +469,8 @@ class ExploreViewModel @Inject constructor(
     }
 
     private fun clearSearchResults() {
-        _pagingSearchResults.value = PagingData.from(listOf())
-        _physicalSearchResults.value = listOf()
+        _pagingSearchResults.postValue(PagingData.from(listOf()))
+        _physicalSearchResults.postValue(listOf())
     }
 
     private fun getBoundedFlow(

--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -202,7 +202,7 @@ public class WalletApplication extends BaseWalletApplication implements AutoLogo
 
         WorkManager.getInstance(this.getApplicationContext()).enqueueUniqueWork(
                 "Sync Explore Data",
-                ExistingWorkPolicy.REPLACE,
+                ExistingWorkPolicy.KEEP,
                 syncDataWorkRequest
         );
     }


### PR DESCRIPTION
When the user switches the filter tab, e.g. from All to Online, the results of the All tab are still showing for a short while before Online results are loaded. This might introduce some confusion.

## Issue being fixed or feature implemented
Clearing search results immediately after switching a tab.

Additionally, I've changed `ExistingWorkPolicy` to `Keep` for the explore sync worker so that the ongoing work doesn't get interrupted (which seems to be a cause of failed synchronization in some cases).

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
