### PR TITLE
fix: refresh buy & sell UI immediately upon login/logout from a service

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/BuyAndSellLiquidUpholdActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/BuyAndSellLiquidUpholdActivity.kt
@@ -134,6 +134,7 @@ class BuyAndSellLiquidUpholdActivity : LockScreenActivity() {
         if (!LiquidConstants.hasValidCredentials() || !UpholdConstants.hasValidCredentials()) {
             keys_missing_error.isVisible = true
         }
+        dash_services_list.setHasFixedSize(true)
         dash_services_list.adapter = buyAndSellDashServicesAdapter
     }
 
@@ -185,7 +186,7 @@ class BuyAndSellLiquidUpholdActivity : LockScreenActivity() {
         }
 
         viewModel.servicesList.observe(this) {
-            buyAndSellDashServicesAdapter.submitList(it)
+            buyAndSellDashServicesAdapter.submitList(it.toMutableList())
         }
 
         viewModel.upholdBalanceLiveData.observe(this) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
Upon successful login/logout from the one of the services available to purchase Dash in `Buy & Sell Dash` UI, the state of the service wasn't updated accordingly in the list, unless we left the screen and resumed it afterwards 
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
