### PR TITLE
[NMA-1141 && NMA-1139 && NMA-1153] Explore Dash fixes

### DIFF
--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/AtmDao.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/AtmDao.kt
@@ -146,7 +146,7 @@ interface AtmDao : BaseDao<Atm> {
         FROM atm
         JOIN atm_fts ON atm.id = atm_fts.docid
         WHERE atm_fts MATCH :query
-            AND (:territoryFilter = '' OR atm_fts.territory = :territoryFilter)
+            AND (:territoryFilter = '' OR territory = :territoryFilter)
             AND type IN (:types)
         ORDER BY
             CASE WHEN :sortByDistance = 1 THEN (latitude - :anchorLat)*(latitude - :anchorLat) + (longitude - :anchorLng)*(longitude - :anchorLng) END ASC, 
@@ -166,7 +166,7 @@ interface AtmDao : BaseDao<Atm> {
         FROM atm
         JOIN atm_fts ON atm.id = atm_fts.docid
         WHERE atm_fts MATCH :query
-            AND (:territoryFilter = '' OR atm_fts.territory = :territoryFilter)
+            AND (:territoryFilter = '' OR territory = :territoryFilter)
             AND type IN (:types)
     """)
     suspend fun searchByTerritoryResultCount(
@@ -230,7 +230,7 @@ interface AtmDao : BaseDao<Atm> {
         FROM atm
         JOIN atm_fts ON atm.id = atm_fts.docid
         WHERE atm_fts MATCH :query
-            AND (:territoryFilter = '' OR atm_fts.territory = :territoryFilter)
+            AND (:territoryFilter = '' OR territory = :territoryFilter)
             AND type IN (:types)
         ORDER BY name ASC
     """)

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/ExploreDataSource.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/ExploreDataSource.kt
@@ -134,9 +134,9 @@ open class MerchantAtmDataSource @Inject constructor(
                 val types = listOf(MerchantType.ONLINE, MerchantType.BOTH)
 
                 if (query.isNotBlank()) {
-                    merchantDao.pagingSearchGrouped(sanitizeQuery(query), types, paymentMethod)
+                    merchantDao.pagingSearchGrouped(sanitizeQuery(query), types, paymentMethod, userLat, userLng)
                 } else {
-                    merchantDao.pagingGetGrouped(types, paymentMethod)
+                    merchantDao.pagingGetGrouped(types, paymentMethod, userLat, userLng)
                 }
             }
             type == MerchantType.PHYSICAL && territory.isBlank() && bounds != GeoBounds.noBounds -> {

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/MerchantDao.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/MerchantDao.kt
@@ -203,7 +203,7 @@ interface MerchantDao : BaseDao<Merchant> {
         FROM merchant
         JOIN merchant_fts ON merchant.id = merchant_fts.docid
         WHERE merchant_fts MATCH :query
-            AND (:territoryFilter = '' OR merchant_fts.territory = :territoryFilter)
+            AND (:territoryFilter = '' OR territory = :territoryFilter)
             AND (:paymentMethod = '' OR paymentMethod = :paymentMethod)
             AND type IN (:types)
         GROUP BY source, merchantId
@@ -234,7 +234,7 @@ interface MerchantDao : BaseDao<Merchant> {
         FROM merchant
         JOIN merchant_fts ON merchant.id = merchant_fts.docid
         WHERE merchant_fts MATCH :query
-            AND (:territoryFilter = '' OR merchant_fts.territory = :territoryFilter)
+            AND (:territoryFilter = '' OR territory = :territoryFilter)
             AND (:paymentMethod = '' OR paymentMethod = :paymentMethod)
             AND type IN (:types)
     """)
@@ -378,7 +378,7 @@ interface MerchantDao : BaseDao<Merchant> {
         FROM merchant
         JOIN merchant_fts ON merchant.id = merchant_fts.docid
         WHERE merchant_fts MATCH :query
-            AND (:territoryFilter = '' OR merchant_fts.territory = :territoryFilter)
+            AND (:territoryFilter = '' OR territory = :territoryFilter)
             AND (:paymentMethod = '' OR paymentMethod = :paymentMethod)
             AND (:excludeType = '' OR type != :excludeType)
     """)

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/MerchantDao.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/MerchantDao.kt
@@ -252,11 +252,14 @@ interface MerchantDao : BaseDao<Merchant> {
         WHERE (:paymentMethod = '' OR paymentMethod = :paymentMethod)
             AND type IN (:types)
         GROUP BY source, merchantId
+        HAVING (latitude - :anchorLat)*(latitude - :anchorLat) + (longitude - :anchorLng)*(longitude - :anchorLng) = MIN((latitude - :anchorLat)*(latitude - :anchorLat) + (longitude - :anchorLng)*(longitude - :anchorLng))
         ORDER BY name COLLATE NOCASE ASC
     """)
     fun pagingGetGrouped(
         types: List<String>,
-        paymentMethod: String
+        paymentMethod: String,
+        anchorLat: Double,
+        anchorLng: Double
     ): PagingSource<Int, MerchantInfo>
 
     @Query("""
@@ -279,12 +282,15 @@ interface MerchantDao : BaseDao<Merchant> {
             AND (:paymentMethod = '' OR paymentMethod = :paymentMethod)
             AND type IN (:types)
         GROUP BY source, merchantId
+        HAVING (latitude - :anchorLat)*(latitude - :anchorLat) + (longitude - :anchorLng)*(longitude - :anchorLng) = MIN((latitude - :anchorLat)*(latitude - :anchorLat) + (longitude - :anchorLng)*(longitude - :anchorLng))
         ORDER BY name COLLATE NOCASE ASC
     """)
     fun pagingSearchGrouped(
         query: String,
         types: List<String>,
-        paymentMethod: String
+        paymentMethod: String,
+        anchorLat: Double,
+        anchorLng: Double
     ): PagingSource<Int, MerchantInfo>
 
     @Query("""

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/model/AtmFTS.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/model/AtmFTS.kt
@@ -24,12 +24,5 @@ import androidx.room.Fts4
 @Entity(tableName = "atm_fts")
 @Fts4(contentEntity = Atm::class)
 data class AtmFTS(
-    val name: String,
-    val manufacturer: String,
-    val address1: String,
-    val address2: String,
-    val address3: String,
-    val address4: String,
-    val city: String,
-    val territory: String
+    val name: String
 )

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/model/MerchantFTS.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/model/MerchantFTS.kt
@@ -24,11 +24,5 @@ import androidx.room.Fts4
 @Entity(tableName = "merchant_fts")
 @Fts4(contentEntity = Merchant::class)
 data class MerchantFTS(
-    val name: String,
-    val address1: String,
-    val address2: String,
-    val address3: String,
-    val address4: String,
-    val city: String,
-    var territory: String
+    val name: String
 )

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ExploreMapFragment.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ExploreMapFragment.kt
@@ -131,16 +131,14 @@ class ExploreMapFragment : SupportMapFragment() {
         }
 
         viewModel.screenState.observe(viewLifecycleOwner) { state ->
-            if (viewModel.filterMode.value == FilterMode.Online) {
-                return@observe
-            }
-
             selectedMarker?.remove()
             markersGlideRequestManager.clear(selectedIconRequest)
 
             if (state == ScreenState.Details || state == ScreenState.DetailsGrouped) {
                 showSelectedMarker(state)
-            } else if (viewModel.isLocationEnabled.value == true) {
+            } else if (viewModel.isLocationEnabled.value == true &&
+                (state == ScreenState.MerchantLocations || viewModel.filterMode.value != FilterMode.Online)
+            ) {
                 showMarkerSet(state)
             }
 
@@ -470,8 +468,7 @@ class ExploreMapFragment : SupportMapFragment() {
     }
 
     private fun canFocusOnItem(item: SearchResult): Boolean =
-        viewModel.filterMode.value != FilterMode.Online &&
-                item.type != MerchantType.ONLINE &&
+        item.type != MerchantType.ONLINE &&
                 item.latitude != null && item.longitude != null
 
     private fun getBitmapFromDrawable(drawableId: Int): Bitmap? {

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ExploreViewModel.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ExploreViewModel.kt
@@ -91,7 +91,10 @@ class ExploreViewModel @Inject constructor(
 
     val isMetric = Locale.getDefault().isMetric
 
-    private val searchQuery = MutableStateFlow("")
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: String
+        get() = _searchQuery.value
+
     var exploreTopic = ExploreTopic.Merchants
         private set
 
@@ -191,7 +194,7 @@ class ExploreViewModel @Inject constructor(
         get() = _screenState
 
     // Used for the list of search results
-    private val pagingSearchFlow: Flow<PagingData<SearchResult>> = searchQuery
+    private val pagingSearchFlow: Flow<PagingData<SearchResult>> = _searchQuery
         .debounce(QUERY_DEBOUNCE_VALUE)
         .flatMapLatest { query ->
             _paymentMethodFilter.flatMapLatest { payment ->
@@ -235,7 +238,7 @@ class ExploreViewModel @Inject constructor(
         }
 
     // Used for the map
-    val boundedSearchFlow = searchQuery
+    val boundedSearchFlow = _searchQuery
         .debounce(QUERY_DEBOUNCE_VALUE)
         .flatMapLatest { query ->
             _paymentMethodFilter.flatMapLatest { payment ->
@@ -338,7 +341,7 @@ class ExploreViewModel @Inject constructor(
     }
 
     fun submitSearchQuery(query: String) {
-        searchQuery.value = query
+        _searchQuery.value = query
     }
 
     suspend fun getTerritoriesWithPOIs(): List<String> {
@@ -462,7 +465,7 @@ class ExploreViewModel @Inject constructor(
     }
 
     fun clearFilters() {
-        searchQuery.value = ""
+        _searchQuery.value = ""
         _selectedTerritory.value = ""
         _paymentMethodFilter.value = ""
         _selectedRadiusOption.value = DEFAULT_RADIUS_OPTION
@@ -522,12 +525,7 @@ class ExploreViewModel @Inject constructor(
                 data.filter { it.merchant != null }
                     .map {
                         it.merchant!!.apply {
-                            this.physicalAmount =
-                                if (filterMode != FilterMode.Online) {
-                                    it.physicalAmount ?: 1
-                                } else {
-                                    0
-                                }
+                            this.physicalAmount = it.physicalAmount ?: 0
                             this.distance = calculateDistance(this, userLat, userLng)
                         }
                     }
@@ -563,13 +561,13 @@ class ExploreViewModel @Inject constructor(
             val result = if (exploreTopic == ExploreTopic.Merchants) {
                 val type = getMerchantType(filterMode.value ?: FilterMode.Online)
                 exploreData.getMerchantsResultCount(
-                        searchQuery.value, selectedTerritory.value!!, type,
+                        _searchQuery.value, selectedTerritory.value!!, type,
                         paymentMethodFilter, radiusBounds ?: GeoBounds.noBounds
                 )
             } else {
                 val types = getAtmTypes(filterMode.value ?: FilterMode.All)
                 exploreData.getAtmsResultsCount(
-                        searchQuery.value, types,
+                        _searchQuery.value, types,
                         selectedTerritory.value!!, radiusBounds ?: GeoBounds.noBounds
                 )
             }

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ItemDetails.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ItemDetails.kt
@@ -52,9 +52,9 @@ class ItemDetails(context: Context, attrs: AttributeSet): LinearLayout(context, 
         updatePaddingRelative(start = horizontalPadding, end = horizontalPadding)
     }
 
-    fun bindItem(item: SearchResult, filterMode: FilterMode) {
+    fun bindItem(item: SearchResult) {
         if (item is Merchant) {
-            bindMerchantDetails(item, filterMode)
+            bindMerchantDetails(item)
         } else if (item is Atm) {
             bindAtmDetails(item)
         }
@@ -118,10 +118,10 @@ class ItemDetails(context: Context, attrs: AttributeSet): LinearLayout(context, 
         }
     }
 
-    private fun bindMerchantDetails(merchant: Merchant, filterMode: FilterMode) {
+    private fun bindMerchantDetails(merchant: Merchant) {
         binding.apply {
             val isGrouped = merchant.physicalAmount > 0
-            val isOnline = merchant.type == MerchantType.ONLINE || filterMode == FilterMode.Online
+            val isOnline = merchant.type == MerchantType.ONLINE
 
             buySellContainer.isVisible = false
             locationHint.isVisible = false

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/SearchFragment.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/SearchFragment.kt
@@ -317,7 +317,7 @@ class SearchFragment : Fragment(R.layout.fragment_search) {
 
         viewModel.selectedItem.observe(viewLifecycleOwner) { item ->
             if (item != null) {
-                binding.itemDetails.bindItem(item, viewModel.filterMode.value ?: FilterMode.Online)
+                binding.itemDetails.bindItem(item)
                 binding.toolbarTitle.text = item.name
             } else {
                 binding.toolbarTitle.text = getToolbarTitle()
@@ -399,8 +399,7 @@ class SearchFragment : Fragment(R.layout.fragment_search) {
 
     private fun transitToDetails() {
         val item = viewModel.selectedItem.value ?: return
-        val isOnline = viewModel.filterMode.value == FilterMode.Online ||
-                item.type == MerchantType.ONLINE
+        val isOnline = item.type == MerchantType.ONLINE
 
         val bottomSheet = BottomSheetBehavior.from(binding.contentPanel)
         bottomSheetWasExpanded = bottomSheet.state == BottomSheetBehavior.STATE_EXPANDED
@@ -439,6 +438,8 @@ class SearchFragment : Fragment(R.layout.fragment_search) {
         }
 
         binding.searchResults.adapter = ConcatAdapter(searchHeaderAdapter, searchResultsAdapter)
+        searchHeaderAdapter.searchText = viewModel.searchQuery
+
         val layoutParams = binding.searchResults.layoutParams as ConstraintLayout.LayoutParams
         layoutParams.topMargin = resources.getDimensionPixelOffset(R.dimen.search_results_margin_top)
         binding.searchResults.isVisible = true
@@ -630,8 +631,7 @@ class SearchFragment : Fragment(R.layout.fragment_search) {
     private fun isBottomSheetDraggable(): Boolean {
         val screenState = viewModel.screenState.value
         val isDetails = screenState == ScreenState.DetailsGrouped || screenState == ScreenState.Details
-        val nearbySearch = viewModel.filterMode.value != FilterMode.Online &&
-                viewModel.selectedTerritory.value.isNullOrEmpty() &&
+        val nearbySearch = viewModel.selectedTerritory.value.isNullOrEmpty() &&
                 viewModel.isLocationEnabled.value == true
 
         return !isDetails && nearbySearch
@@ -641,8 +641,7 @@ class SearchFragment : Fragment(R.layout.fragment_search) {
     private fun setBottomSheetState(forceExpand: Boolean = false): Int {
         val screenState = viewModel.screenState.value
         val isDetails = screenState == ScreenState.DetailsGrouped || screenState == ScreenState.Details
-        val nearbySearch = viewModel.filterMode.value != FilterMode.Online &&
-                           viewModel.selectedTerritory.value.isNullOrEmpty() &&
+        val nearbySearch = viewModel.selectedTerritory.value.isNullOrEmpty() &&
                            viewModel.isLocationEnabled.value == true
 
         return when {

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/adapters/SearchHeaderAdapter.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/adapters/SearchHeaderAdapter.kt
@@ -56,6 +56,17 @@ class SearchHeaderAdapter(private val topic: ExploreTopic) : RecyclerView.Adapte
             }
         }
 
+    private var _searchText = ""
+    var searchText: String
+        get() = _searchText
+        set(value) {
+            _searchText = value
+
+            if (::binding.isInitialized) {
+                binding.search.setText(value)
+            }
+        }
+
     override fun getItemCount() = 1
 
     override fun getItemViewType(position: Int) = R.layout.search_header_view
@@ -96,6 +107,7 @@ class SearchHeaderAdapter(private val topic: ExploreTopic) : RecyclerView.Adapte
         }
 
         binding.search.doOnTextChanged { text, _, _, _ ->
+            _searchText = text.toString()
             binding.clearBtn.isVisible = !text.isNullOrEmpty()
             onSearchQueryChanged?.invoke(text.toString())
         }
@@ -116,6 +128,7 @@ class SearchHeaderAdapter(private val topic: ExploreTopic) : RecyclerView.Adapte
             onFilterButtonClicked?.invoke()
         }
 
+        binding.search.setText(searchText)
         binding.searchTitle.text = title
         binding.searchSubtitle.text = subtitle
         binding.searchSubtitle.isVisible = subtitle.isNotEmpty()
@@ -145,7 +158,7 @@ class SearchHeaderAdapter(private val topic: ExploreTopic) : RecyclerView.Adapte
     }
 
     fun clearSearchQuery() {
-        binding.search.text.clear()
+        searchText = ""
     }
 
     fun setOnFilterOptionChosen(listener: (FilterMode) -> Unit) {

--- a/features/exploredash/src/test/java/org/dash/wallet/features/exploredash/MerchantAtmDataSourceTest.kt
+++ b/features/exploredash/src/test/java/org/dash/wallet/features/exploredash/MerchantAtmDataSourceTest.kt
@@ -44,11 +44,11 @@ class TestPagingSource : PagingSource<Int, MerchantInfo>() {
 class MerchantDaoTest {
     private val atmDaoMock = mock<AtmDao>()
     private val merchantDaoMock = mock<MerchantDao> {
-        on { pagingGetGrouped(any(), any()) } doReturn TestPagingSource()
+        on { pagingGetGrouped(any(), any(), any(), any()) } doReturn TestPagingSource()
         on { pagingGetByTerritory(any(), any(), any(), any(), any(), any(), any(), any()) } doReturn TestPagingSource()
         on { pagingGetByCoordinates(any(), any(), any(), any(), any(), any(), any(), any(), any()) } doReturn TestPagingSource()
 
-        on { pagingSearchGrouped(any(), any(), any()) } doReturn TestPagingSource()
+        on { pagingSearchGrouped(any(), any(), any(), any(), any()) } doReturn TestPagingSource()
         on { pagingSearchByTerritory(any(), any(), any(), any(), any(), any(), any(), any(), any()) } doReturn TestPagingSource()
         on { pagingSearchByCoordinates(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } doReturn TestPagingSource()
     }
@@ -70,7 +70,7 @@ class MerchantDaoTest {
         dataSourceSpy.observeMerchantsPaging("", "", MerchantType.ONLINE, "",
             GeoBounds.noBounds, false, 0.0, 0.0, false)
 
-        verify(merchantDaoMock).pagingGetGrouped(requiredOnlineTypes, "")
+        verify(merchantDaoMock).pagingGetGrouped(requiredOnlineTypes, "", 0.0, 0.0)
         verifyNoMoreInteractions(merchantDaoMock)
 
         // --- Online type with query should call sanitizeQuery and pagingSearchGrouped methods ---
@@ -81,7 +81,7 @@ class MerchantDaoTest {
             GeoBounds.noBounds, false, 0.0, 0.0, false)
 
         verify(dataSourceSpy).sanitizeQuery(query)
-        verify(merchantDaoMock).pagingSearchGrouped(sanitizedQuery, requiredOnlineTypes, "")
+        verify(merchantDaoMock).pagingSearchGrouped(sanitizedQuery, requiredOnlineTypes, "", 0.0, 0.0)
         verifyNoMoreInteractions(merchantDaoMock)
     }
 

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -175,8 +175,8 @@ android {
     defaultConfig {
         minSdkVersion 23
         targetSdkVersion 30
-        versionCode project.hasProperty('versionCode') ? project.property('versionCode') as int : 70350
-        versionName project.hasProperty('versionName') ? project.property('versionName') : "7.3.5"
+        versionCode project.hasProperty('versionCode') ? project.property('versionCode') as int : 70410
+        versionName project.hasProperty('versionName') ? project.property('versionName') : "7.4.1"
         multiDexEnabled true
         generatedDensities = ['hdpi', 'xhdpi']
         vectorDrawables.useSupportLibrary = true

--- a/wallet/src/de/schildbach/wallet/data/AppDatabaseMigrations.kt
+++ b/wallet/src/de/schildbach/wallet/data/AppDatabaseMigrations.kt
@@ -41,12 +41,10 @@ class AppDatabaseMigrations {
 
 
                 database.execSQL("CREATE VIRTUAL TABLE IF NOT EXISTS `merchant_fts` " +
-                        "USING FTS4(`name`, `address1`, `address2`, `address3`, `address4`, " +
-                        "`territory`, `city`, content=`merchant`)")
+                        "USING FTS4(`name`, content=`merchant`)")
 
                 database.execSQL("CREATE VIRTUAL TABLE IF NOT EXISTS `atm_fts` " +
-                        "USING FTS4(`name`, `manufacturer`, `address1`, `address2`, `address3`, " +
-                        "`address4`, `city`, `territory`, content=`atm`)")
+                        "USING FTS4(`name`, content=`atm`)")
             }
         }
     }


### PR DESCRIPTION
We want to show a full details card for `both` merchants even if opened from the Online tab.
Additionally, when details are opened and then the user goes back to the search screen, the search query is erased but search results are still filtered.
The last fix is grouping in the Online tab, which was by name but should be by the distance.

## Issue being fixed or feature implemented
- Removed all conditions that limit the full details card from opening in `FilterMode.Online` and only left checks for `MerchantType.Online`.
- Now setting search text explicitly when transitioning to the SearchResults screen mode.
- Changed grouping in Online tab to be by a Pythagorean formula like in all the other cases.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
