### PR TITLE
fix: use context parameter instead of calling requireContext

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
+++ b/wallet/src/de/schildbach/wallet/ui/CheckPinDialog.kt
@@ -334,10 +334,10 @@ open class CheckPinDialog : DialogFragment() {
     }
 
     protected open fun showLockedAlert(context: Context) {
-        BaseAlertDialogBuilder(requireContext()).apply {
-            title = getString(R.string.wallet_lock_wallet_disabled)
+        BaseAlertDialogBuilder(context).apply {
+            title = context.getString(R.string.wallet_lock_wallet_disabled)
             message = pinRetryController.getWalletTemporaryLockedMessage(context)
-            positiveText = getString(android.R.string.ok)
+            positiveText = context.getString(android.R.string.ok)
         }.buildAlertDialog().show()
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->
There is a crash if CheckPinDialog is created during a wait period from entering the incorrect PIN.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
