### PR TITLE
[NMA-1190] fix: Hilt crash in OnboardingActivity

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/ui/BaseDialogFragment.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/BaseDialogFragment.kt
@@ -6,14 +6,16 @@ import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
-import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
-@AndroidEntryPoint
 @Deprecated("Use AdaptiveDialog")
 abstract class BaseDialogFragment : DialogFragment() {
     protected lateinit var alertDialog: AlertDialog
-    @Inject lateinit var baseAlertDialogBuilder: BaseAlertDialogBuilder
+    lateinit var baseAlertDialogBuilder: BaseAlertDialogBuilder
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        baseAlertDialogBuilder = BaseAlertDialogBuilder(requireContext())
+    }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         Log.e(this::class.java.simpleName, "onCreateDialog")

--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -809,7 +809,8 @@ public class WalletApplication extends BaseWalletApplication implements AutoLogo
         if (walletBackupFile.exists()) {
             walletBackupFile.delete();
         }
-        ProcessPhoenix.triggerRebirth(this);
+        // wallet must be null for the OnboardingActivity flow
+        wallet = null;
     }
 
     public static WalletApplication getInstance() {

--- a/wallet/src/de/schildbach/wallet/ui/ResetWalletDialog.kt
+++ b/wallet/src/de/schildbach/wallet/ui/ResetWalletDialog.kt
@@ -17,16 +17,20 @@
 package de.schildbach.wallet.ui
 
 import android.app.Dialog
+import android.content.DialogInterface
 import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
 import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet_test.R
 import org.dash.wallet.common.services.analytics.AnalyticsConstants
 import org.dash.wallet.common.services.analytics.FirebaseAnalyticsServiceImpl
 import org.dash.wallet.common.ui.BaseAlertDialogBuilder
-import org.dash.wallet.common.ui.BaseDialogFragment
+import org.dash.wallet.common.ui.dismissDialog
 
-class ResetWalletDialog : BaseDialogFragment() {
+class ResetWalletDialog : DialogFragment() {
+    private lateinit var alertDialog: AlertDialog
     private val analytics = FirebaseAnalyticsServiceImpl.getInstance()
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -44,7 +48,13 @@ class ResetWalletDialog : BaseDialogFragment() {
                 cancelable = false
                 isCancelableOnTouchOutside = false
             }.buildAlertDialog()
-        return super.onCreateDialog(savedInstanceState)
+
+        return alertDialog
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        alertDialog.dismissDialog()
     }
 
     companion object {

--- a/wallet/src/de/schildbach/wallet/ui/ResetWalletDialog.kt
+++ b/wallet/src/de/schildbach/wallet/ui/ResetWalletDialog.kt
@@ -42,7 +42,12 @@ class ResetWalletDialog : DialogFragment() {
                 negativeAction = {
                     analytics.logEvent(AnalyticsConstants.Security.RESET_WALLET, bundleOf())
                     (activity as? AbstractBindServiceActivity)?.unbindServiceServiceConnection()
+                    // 1. wipe the wallet
+                    // 2. start OnboardingActivity
+                    // 3. close the backstack (Home->More->Security)
                     WalletApplication.getInstance().triggerWipe(context)
+                    startActivity(OnboardingActivity.createIntent(requireContext()))
+                    activity?.finishAffinity()
                 }
                 positiveText = getString(android.R.string.no)
                 cancelable = false


### PR DESCRIPTION
There is a crash in the `OnboardingActivity` on the "Wallet is permanently locked" screen, when the user tries to initiate a reset dialog. It happens because `BaseDialogFragment` is annotated as `@AndroidEntryPoint`, while the `OnboardingActivity` isn't.

## Issue being fixed or feature implemented
A couple of changes are made:
- We could annotate `OnboardingActivity` as `@AndroidEntryPoint`, however, the fact that the `BaseDialogFragment` is annotated creates various side effects around the app (like this bug). It's better to avoid  `@AndroidEntryPoint` in the dialogs, so I have removed it and made related changes.
- Given that the `BaseDialogFragment` is obsolete and unnesasary (`DialogFragments` are dismissed automatically now), I have uncoupled the `ResetWalletDialog` from it.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
