### PR TITLE
fix: copying text on the About screen

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/AboutActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/AboutActivity.kt
@@ -138,7 +138,7 @@ class AboutActivity : BaseMenuActivity() {
     private fun TextView.setCopyable(label: String) {
         this.setOnClickListener {
             (getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager).run {
-                setPrimaryClip(ClipData.newPlainText(label, this.text))
+                setPrimaryClip(ClipData.newPlainText(label, this@setCopyable.text))
             }
             Toast(this@AboutActivity).toast("Copied")
         }


### PR DESCRIPTION
There is a small bug that prevents text on the About screen from being copied. `ClipboardManager` gets text from itself instead of a TextView.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
