### PR TITLE
[NMA-1186] QR code bugfix

### DIFF
--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation "org.dashj.android:dashj-scrypt-android:0.17.5"
     implementation 'io.grpc:grpc-stub:1.28.0' // CURRENT_GRPC_VERSION
     implementation 'com.google.guava:guava:29.0-android'
-    implementation 'com.google.zxing:core:3.4.1'
+    implementation 'com.google.zxing:core:3.3.3' // Don't update. 3.3.3 is the maximum to support Android 6.x
 
     implementation "com.squareup.okhttp3:okhttp:$ok_http_version"
     implementation "com.squareup.okhttp3:logging-interceptor:$ok_http_version"

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation "org.dashj.android:dashj-scrypt-android:0.17.5"
     implementation 'io.grpc:grpc-stub:1.28.0' // CURRENT_GRPC_VERSION
     implementation 'com.google.guava:guava:29.0-android'
+    //noinspection GradleDependency
     implementation 'com.google.zxing:core:3.3.3' // Don't update. 3.3.3 is the maximum to support Android 6.x
 
     implementation "com.squareup.okhttp3:okhttp:$ok_http_version"

--- a/wallet/src/de/schildbach/wallet/ui/PaymentsPayFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/PaymentsPayFragment.kt
@@ -147,7 +147,7 @@ class PaymentsPayFragment : BaseLockScreenFragment() {
                 if (fireAction) {
                     alertDialog = baseAlertDialogBuilder.apply {
                         title = getString(errorDialogTitleResId)
-                        message = requireContext().formatString(messageResId, messageArgs)
+                        message = getString(messageResId, *messageArgs)
                         neutralText = getString(R.string.button_dismiss)
                     }.buildAlertDialog()
                     alertDialog.show()


### PR DESCRIPTION
There is a crash when scanning a QR code on Android 6. Also, the error dialog of a bad dash address has formatting issues.

## Issue being fixed or feature implemented
- Downgraded `zxing` library to version `3.3.3` that works well on Android 6.
- Replaced `formatString` helper method with `getString()`. `formatString` doesn't seem to work well in Kotlin.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
