### PR TITLE
[NMA-1195 & NMA-1197 & NMA-1201] (CrowdNode) Background signup & bug fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ buildscript {
         ok_http_version = '3.12.12'
         dashjVersion = '0.17.10'
         hiltVersion = '2.38.1'
+        hiltWorkVersion = '1.0.0'
+        workRuntimeVersion='2.6.0'
         firebaseVersion = '28.4.2'
         roomVersion = '2.3.0'
         lifecycleVersion = '2.3.1'

--- a/common/src/main/java/org/dash/wallet/common/Configuration.java
+++ b/common/src/main/java/org/dash/wallet/common/Configuration.java
@@ -104,6 +104,7 @@ public class Configuration {
 
     // CrowdNode
     public static final String PREFS_KEY_CROWDNODE_ACCOUNT_ADDRESS = "crowdnode_account_address";
+    public static final String PREFS_KEY_CROWDNODE_ERROR = "crowdnode_error";
 
     private static final Logger log = LoggerFactory.getLogger(Configuration.class);
 
@@ -545,5 +546,13 @@ public class Configuration {
 
     public void setCrowdNodeAccountAddress(@NotNull String address) {
         prefs.edit().putString(PREFS_KEY_CROWDNODE_ACCOUNT_ADDRESS, address).apply();
+    }
+
+    public String getCrowdNodeError() {
+        return prefs.getString(PREFS_KEY_CROWDNODE_ERROR, "");
+    }
+
+    public void setCrowdNodeError(String error) {
+        prefs.edit().putString(PREFS_KEY_CROWDNODE_ERROR, error).apply();
     }
 }

--- a/common/src/main/java/org/dash/wallet/common/WalletDataProvider.kt
+++ b/common/src/main/java/org/dash/wallet/common/WalletDataProvider.kt
@@ -30,6 +30,8 @@ import org.dash.wallet.common.transactions.TransactionWrapper
 
 interface WalletDataProvider {
 
+    val networkParameters: NetworkParameters
+
     fun currentReceiveAddress(): Address
 
     fun freshReceiveAddress(): Address

--- a/common/src/main/java/org/dash/wallet/common/WalletDataProvider.kt
+++ b/common/src/main/java/org/dash/wallet/common/WalletDataProvider.kt
@@ -52,4 +52,8 @@ interface WalletDataProvider {
     fun observeTransactions(vararg filters: TransactionFilter): Flow<Transaction>
 
     fun wrapAllTransactions(vararg wrappers: TransactionWrapper): Iterable<TransactionWrapper>
+
+    fun attachOnWalletWipedListener(listener: () -> Unit)
+
+    fun detachOnWalletWipedListener(listener: () -> Unit)
 }

--- a/common/src/main/java/org/dash/wallet/common/services/NotificationService.kt
+++ b/common/src/main/java/org/dash/wallet/common/services/NotificationService.kt
@@ -17,8 +17,20 @@
 
 package org.dash.wallet.common.services
 
+import android.app.Notification
 import android.content.Intent
 
 interface NotificationService {
-    fun showNotification(tag: String, message: String, intent: Intent? = null)
+    fun showNotification(
+        tag: String,
+        message: String,
+        isOngoing: Boolean = false,
+        intent: Intent? = null
+    )
+
+    fun buildNotification(
+        message: String,
+        isOngoing: Boolean = false,
+        intent: Intent? = null
+    ): Notification
 }

--- a/features/exploredash/build.gradle
+++ b/features/exploredash/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     // Core
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.work:work-runtime-ktx:2.6.0'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$coroutines_version"
 
     // Architecture
@@ -65,7 +64,6 @@ dependencies {
     // DI
     implementation "com.google.dagger:hilt-android:$hiltVersion"
     kapt "com.google.dagger:hilt-compiler:$hiltVersion"
-    implementation 'androidx.hilt:hilt-work:1.0.0'
     kapt 'androidx.hilt:hilt-compiler:1.0.0'
 
     // UI

--- a/integrations/crowdnode/build.gradle
+++ b/integrations/crowdnode/build.gradle
@@ -60,6 +60,8 @@ dependencies {
 
     // DI
     implementation "com.google.dagger:hilt-android:$hiltVersion"
+    implementation "androidx.hilt:hilt-work:$hiltWorkVersion"
+    implementation "androidx.work:work-runtime-ktx:$workRuntimeVersion"
     kapt "com.google.dagger:hilt-android-compiler:$hiltVersion"
     kapt "androidx.hilt:hilt-compiler:1.0.0"
 

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/api/CrowdNodeApi.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/api/CrowdNodeApi.kt
@@ -88,6 +88,9 @@ class CrowdNodeBlockchainApi @Inject constructor(
 
     init {
         restoreStatus()
+        walletDataProvider.attachOnWalletWipedListener {
+            reset()
+        }
     }
 
     override fun persistentSignUp(accountAddress: Address) {
@@ -155,6 +158,7 @@ class CrowdNodeBlockchainApi @Inject constructor(
     }
 
     override fun reset() {
+        log.info("reset is triggered")
         signUpStatus.value = SignUpStatus.NotStarted
         existingAccountAddress = null
         apiError = null

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/api/CrowdNodeWorker.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/api/CrowdNodeWorker.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dash.wallet.integrations.crowdnode.api
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import org.bitcoinj.core.Address
+import org.dash.wallet.common.WalletDataProvider
+import org.dash.wallet.common.services.NotificationService
+import org.dash.wallet.common.services.analytics.AnalyticsService
+import org.dash.wallet.integrations.crowdnode.R
+import org.slf4j.LoggerFactory
+
+@HiltWorker
+class CrowdNodeWorker @AssistedInject constructor(
+    @Assisted val appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val crowdNodeApi: CrowdNodeApi,
+    private val walletDataProvider: WalletDataProvider,
+    private val notificationService: NotificationService,
+    private val analytics: AnalyticsService
+): CoroutineWorker(appContext, workerParams) {
+    companion object {
+        private val log = LoggerFactory.getLogger(CrowdNodeWorker::class.java)
+
+        const val WORK_NAME = "CrowdNode.WORK"
+        const val API_REQUEST = "CrowdNodeWorker.API_REQUEST"
+        const val SIGNUP_CALL = "CrowdNodeWorker.SIGNUP"
+        const val ACCOUNT_ADDRESS = "CrowdNodeWorker.ACCOUNT_ADDRESS"
+    }
+
+    override suspend fun doWork(): Result {
+        val operation = inputData.getString(API_REQUEST)
+        val accountAddress = inputData.getString(ACCOUNT_ADDRESS)
+        log.info("CrowdNode work started, operation: $operation")
+
+        try {
+            if (!accountAddress.isNullOrEmpty()) {
+                val address = Address.fromBase58(walletDataProvider.networkParameters, accountAddress)
+
+                when (operation) {
+                    SIGNUP_CALL -> {
+                        val notification = notificationService.buildNotification(
+                            appContext.getString(R.string.crowdnode_creating),
+                            true,
+                            crowdNodeApi.notificationIntent
+                        )
+                        log.info("calling setForeground")
+                        setForeground(ForegroundInfo(operation.hashCode(), notification))
+                        crowdNodeApi.signUp(address)
+                    }
+                }
+            }
+
+            return Result.success()
+        } catch (ex: Exception) {
+            analytics.logError(ex, "operation: $operation")
+            log.error("CrowdNode work failed: ${ex.message}", ex)
+            return Result.failure()
+        }
+    }
+}

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/transactions/CrowdNodeAcceptTermsResponse.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/transactions/CrowdNodeAcceptTermsResponse.kt
@@ -18,12 +18,13 @@
 package org.dash.wallet.integrations.crowdnode.transactions
 
 import org.bitcoinj.core.Coin
+import org.bitcoinj.core.NetworkParameters
 import org.dash.wallet.common.transactions.CoinsFromAddressTxFilter
 import org.dash.wallet.integrations.crowdnode.utils.CrowdNodeConstants
 
 // TODO: consider making sure that `toAddress` matches our account address
-class CrowdNodeAcceptTermsResponse: CoinsFromAddressTxFilter(
-    CrowdNodeConstants.CROWDNODE_ADDRESS, ACCEPT_TERMS_RESPONSE_CODE
+class CrowdNodeAcceptTermsResponse(networkParams: NetworkParameters): CoinsFromAddressTxFilter(
+    CrowdNodeConstants.getCrowdNodeAddress(networkParams), ACCEPT_TERMS_RESPONSE_CODE
 ) {
     companion object {
         val ACCEPT_TERMS_RESPONSE_CODE: Coin = CrowdNodeConstants.CROWDNODE_OFFSET + Coin.valueOf(2)

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/transactions/CrowdNodeAcceptTermsTx.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/transactions/CrowdNodeAcceptTermsTx.kt
@@ -18,11 +18,12 @@
 package org.dash.wallet.integrations.crowdnode.transactions
 
 import org.bitcoinj.core.Coin
+import org.bitcoinj.core.NetworkParameters
 import org.dash.wallet.common.transactions.CoinsToAddressTxFilter
 import org.dash.wallet.integrations.crowdnode.utils.CrowdNodeConstants
 
-class CrowdNodeAcceptTermsTx: CoinsToAddressTxFilter(
-    CrowdNodeConstants.CROWDNODE_ADDRESS, ACCEPT_TERMS_REQUEST_CODE
+class CrowdNodeAcceptTermsTx(networkParams: NetworkParameters): CoinsToAddressTxFilter(
+    CrowdNodeConstants.getCrowdNodeAddress(networkParams), ACCEPT_TERMS_REQUEST_CODE
 ) {
     companion object {
         val ACCEPT_TERMS_REQUEST_CODE: Coin = CrowdNodeConstants.CROWDNODE_OFFSET + Coin.valueOf(65536)

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/transactions/CrowdNodeErrorResponse.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/transactions/CrowdNodeErrorResponse.kt
@@ -18,10 +18,11 @@
 package org.dash.wallet.integrations.crowdnode.transactions
 
 import org.bitcoinj.core.Coin
+import org.bitcoinj.core.NetworkParameters
 import org.dash.wallet.common.transactions.CoinsFromAddressTxFilter
 import org.dash.wallet.integrations.crowdnode.utils.CrowdNodeConstants
 
 // TODO: consider making sure that `toAddress` matches our account address
-class CrowdNodeErrorResponse(requestValue: Coin): CoinsFromAddressTxFilter(
-    CrowdNodeConstants.CROWDNODE_ADDRESS, requestValue, includeFee = true
+class CrowdNodeErrorResponse(networkParams: NetworkParameters, requestValue: Coin): CoinsFromAddressTxFilter(
+    CrowdNodeConstants.getCrowdNodeAddress(networkParams), requestValue, includeFee = true
 )

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/transactions/CrowdNodeFullTxSet.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/transactions/CrowdNodeFullTxSet.kt
@@ -18,16 +18,17 @@
 package org.dash.wallet.integrations.crowdnode.transactions
 
 import org.bitcoinj.core.Address
+import org.bitcoinj.core.NetworkParameters
 import org.bitcoinj.core.Transaction
 import org.dash.wallet.common.transactions.TransactionFilter
 import org.dash.wallet.common.transactions.TransactionWrapper
 
-class CrowdNodeFullTxSet: TransactionWrapper {
+class CrowdNodeFullTxSet(networkParams: NetworkParameters): TransactionWrapper {
     private val crowdNodeTxFilters = listOf(
-        CrowdNodeSignUpTx(),
-        CrowdNodeAcceptTermsResponse(),
-        CrowdNodeAcceptTermsTx(),
-        CrowdNodeWelcomeToApiResponse()
+        CrowdNodeSignUpTx(networkParams),
+        CrowdNodeAcceptTermsResponse(networkParams),
+        CrowdNodeAcceptTermsTx(networkParams),
+        CrowdNodeWelcomeToApiResponse(networkParams)
     )
 
     private val matchedFilters = mutableListOf<TransactionFilter>()
@@ -35,9 +36,6 @@ class CrowdNodeFullTxSet: TransactionWrapper {
 
     val hasAcceptTermsResponse: Boolean
         get() = matchedFilters.any { it is CrowdNodeAcceptTermsResponse }
-
-    val hasAcceptTermsRequest: Boolean
-        get() = matchedFilters.any { it is CrowdNodeAcceptTermsTx }
 
     val hasWelcomeToApiResponse: Boolean
         get() = matchedFilters.any { it is CrowdNodeWelcomeToApiResponse }

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/transactions/CrowdNodeSignUpTx.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/transactions/CrowdNodeSignUpTx.kt
@@ -18,11 +18,12 @@
 package org.dash.wallet.integrations.crowdnode.transactions
 
 import org.bitcoinj.core.Coin
+import org.bitcoinj.core.NetworkParameters
 import org.dash.wallet.common.transactions.CoinsToAddressTxFilter
 import org.dash.wallet.integrations.crowdnode.utils.CrowdNodeConstants
 
-class CrowdNodeSignUpTx: CoinsToAddressTxFilter(
-    CrowdNodeConstants.CROWDNODE_ADDRESS, SIGNUP_REQUEST_CODE
+class CrowdNodeSignUpTx(networkParams: NetworkParameters): CoinsToAddressTxFilter(
+    CrowdNodeConstants.getCrowdNodeAddress(networkParams), SIGNUP_REQUEST_CODE
 ) {
     companion object {
         val SIGNUP_REQUEST_CODE: Coin = CrowdNodeConstants.CROWDNODE_OFFSET + Coin.valueOf(131072)

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/transactions/CrowdNodeWelcomeToApiResponse.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/transactions/CrowdNodeWelcomeToApiResponse.kt
@@ -18,12 +18,13 @@
 package org.dash.wallet.integrations.crowdnode.transactions
 
 import org.bitcoinj.core.Coin
+import org.bitcoinj.core.NetworkParameters
 import org.dash.wallet.common.transactions.CoinsFromAddressTxFilter
 import org.dash.wallet.integrations.crowdnode.utils.CrowdNodeConstants
 
 // TODO: consider making sure that `toAddress` matches our account address
-class CrowdNodeWelcomeToApiResponse: CoinsFromAddressTxFilter(
-    CrowdNodeConstants.CROWDNODE_ADDRESS, WELCOME_TO_API_RESPONSE_CODE
+class CrowdNodeWelcomeToApiResponse(networkParams: NetworkParameters): CoinsFromAddressTxFilter(
+    CrowdNodeConstants.getCrowdNodeAddress(networkParams), WELCOME_TO_API_RESPONSE_CODE
 ) {
     companion object {
         val WELCOME_TO_API_RESPONSE_CODE: Coin = CrowdNodeConstants.CROWDNODE_OFFSET + Coin.valueOf(4)

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/CrowdNodeViewModel.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/CrowdNodeViewModel.kt
@@ -99,7 +99,7 @@ class CrowdNodeViewModel @Inject constructor(
         navigationCallback.postValue(NavigationRequest.SendReport)
     }
 
-    fun signUpInBackground() {
+    fun signUp() {
         crowdNodeApi.persistentSignUp(_accountAddress.value!!)
     }
 
@@ -110,7 +110,7 @@ class CrowdNodeViewModel @Inject constructor(
 
     fun retry() {
         reset()
-        signUpInBackground()
+        signUp()
     }
 
     fun changeNotifyWhenDone(toNotify: Boolean) {

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/CrowdNodeViewModel.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/CrowdNodeViewModel.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.bitcoinj.core.Address
 import org.bitcoinj.core.Coin
-import org.bitcoinj.core.Context
 import org.dash.wallet.common.Configuration
 import org.dash.wallet.common.WalletDataProvider
 import org.dash.wallet.common.data.SingleLiveEvent
@@ -100,8 +99,8 @@ class CrowdNodeViewModel @Inject constructor(
         navigationCallback.postValue(NavigationRequest.SendReport)
     }
 
-    suspend fun signUp() {
-        crowdNodeApi.signUp(_accountAddress.value!!)
+    fun signUpInBackground() {
+        crowdNodeApi.persistentSignUp(_accountAddress.value!!)
     }
 
     fun reset() {
@@ -109,13 +108,17 @@ class CrowdNodeViewModel @Inject constructor(
         crowdNodeApi.reset()
     }
 
-    suspend fun retry() {
+    fun retry() {
         reset()
-        signUp()
+        signUpInBackground()
     }
 
-    fun changeNotifyWhenDone(toNotify: Boolean, intent: Intent?) {
-        crowdNodeApi.showNotificationOnFinished(toNotify, intent)
+    fun changeNotifyWhenDone(toNotify: Boolean) {
+        crowdNodeApi.showNotificationOnResult = toNotify
+    }
+
+    fun setNotificationIntent(intent: Intent?) {
+        crowdNodeApi.notificationIntent = intent
     }
 
     private fun getOrCreateAccountAddress(): Address {
@@ -131,8 +134,7 @@ class CrowdNodeViewModel @Inject constructor(
         return if (savedAddress.isNullOrEmpty()) {
             return createNewAccountAddress()
         } else {
-            // TODO: replace with networkParameters getter in the WalletDataProvider
-            Address.fromString(Context.get().params, savedAddress)
+            Address.fromString(walletDataProvider.networkParameters, savedAddress)
         }
     }
 

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/NewAccountFragment.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/NewAccountFragment.kt
@@ -20,7 +20,6 @@ package org.dash.wallet.integrations.crowdnode.ui
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
-import android.content.Intent
 import android.os.Bundle
 import android.text.SpannableStringBuilder
 import android.text.Spanned
@@ -80,7 +79,7 @@ class NewAccountFragment : Fragment(R.layout.fragment_new_account) {
         binding.createAccountBtn.setOnClickListener {
             lifecycleScope.launch {
                 securityModel.requestPinCode(requireActivity())?.let {
-                    viewModel.signUpInBackground()
+                    viewModel.signUp()
                 }
             }
         }

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/NewAccountFragment.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/NewAccountFragment.kt
@@ -26,17 +26,15 @@ import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
-import android.util.Log
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.dash.wallet.common.services.SecurityModel
 import org.dash.wallet.common.ui.viewBinding
@@ -80,10 +78,9 @@ class NewAccountFragment : Fragment(R.layout.fragment_new_account) {
         }
 
         binding.createAccountBtn.setOnClickListener {
-            GlobalScope.launch(Dispatchers.Main) {
+            lifecycleScope.launch {
                 securityModel.requestPinCode(requireActivity())?.let {
-                    // Launching in the global scope so that signup doesn't stop when staking is exited.
-                    viewModel.signUp()
+                    viewModel.signUpInBackground()
                 }
             }
         }
@@ -95,8 +92,6 @@ class NewAccountFragment : Fragment(R.layout.fragment_new_account) {
         }
 
         binding.notifyWhenDone.setOnClickListener {
-            val intent = Intent(requireContext(), requireActivity()::class.java)
-            viewModel.changeNotifyWhenDone(true, intent)
             requireActivity().finish()
         }
 

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/utils/CrowdNodeConstants.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/utils/CrowdNodeConstants.kt
@@ -19,18 +19,22 @@ package org.dash.wallet.integrations.crowdnode.utils
 
 import org.bitcoinj.core.Address
 import org.bitcoinj.core.Coin
-import org.bitcoinj.core.Context
-import org.bitcoinj.params.TestNet3Params
+import org.bitcoinj.core.NetworkParameters
+import org.bitcoinj.params.MainNetParams
 
 object CrowdNodeConstants {
+    private const val CROWDNODE_TESTNET_ADDRESS = "yMY5bqWcknGy5xYBHSsh2xvHZiJsRucjuy"
+    private const val CROWDNODE_MAINNET_ADDRESS = "XjbaGWaGnvEtuQAUoBgDxJWe8ZNv45upG2"
+
     val MINIMUM_REQUIRED_DASH: Coin = Coin.valueOf(1000000)
+    val REQUIRED_FOR_SIGNUP: Coin = MINIMUM_REQUIRED_DASH - Coin.valueOf(100000)
     val CROWDNODE_OFFSET: Coin = Coin.valueOf(20000)
-    val CROWDNODE_ADDRESS: Address = Address.fromBase58(
-        Context.get().params, // TODO: replace with networkParameters getter in the WalletDataProvider
-        if (Context.get().params == TestNet3Params.get()) {
-            "yMY5bqWcknGy5xYBHSsh2xvHZiJsRucjuy"
+
+    fun getCrowdNodeAddress(params: NetworkParameters): Address {
+        return Address.fromBase58(params, if (params == MainNetParams.get()) {
+            CROWDNODE_MAINNET_ADDRESS
         } else {
-            "XjbaGWaGnvEtuQAUoBgDxJWe8ZNv45upG2"
-        }
-    )
+            CROWDNODE_TESTNET_ADDRESS
+        })
+    }
 }

--- a/integrations/crowdnode/src/main/res/values/strings-crowdnode.xml
+++ b/integrations/crowdnode/src/main/res/values/strings-crowdnode.xml
@@ -41,7 +41,7 @@
     <string name="privacy_policy">Privacy Policy</string>
     <string name="crowdnode_account_ready">Your CrowdNode account is set up and ready to use!</string>
     <string name="notify_when_done">Let me know when it’s done</string>
-    <string name="crowdnode_creating">Your CrowdNode account is creating\nDo not close the app…</string>
+    <string name="crowdnode_creating">Your CrowdNode account is creating…</string>
     <string name="accepting_terms">Accepting terms of use…</string>
     <string name="crowdnode_error">We couldn’t create your CrowdNode account.</string>
 

--- a/wallet/AndroidManifest.xml
+++ b/wallet/AndroidManifest.xml
@@ -434,6 +434,12 @@
                 android:resource="@xml/file_provider" />
         </provider>
 
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            tools:node="remove">
+        </provider>
+
         <receiver
             android:name="de.schildbach.wallet.WalletBalanceWidgetProvider"
             android:label="@string/appwidget_wallet_balance_title">

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
     implementation 'androidx.preference:preference-ktx:1.1.1'
-    implementation "androidx.work:work-runtime-ktx:2.4.0"
+    implementation "androidx.work:work-runtime-ktx:$workRuntimeVersion"
     implementation "org.dashj:dashj-core:$dashjVersion"
     //noinspection GradleDependency
     implementation "org.dashj.android:dashj-bls-android:0.17.5"
@@ -120,6 +120,8 @@ dependencies {
     // DI
     implementation "com.google.dagger:hilt-android:$hiltVersion"
     kapt "com.google.dagger:hilt-compiler:$hiltVersion"
+    implementation "androidx.hilt:hilt-work:$hiltWorkVersion"
+    kapt 'androidx.hilt:hilt-compiler:1.0.0'
 
     // Unit tests
     testImplementation 'junit:junit:4.13.2'

--- a/wallet/src/de/schildbach/wallet/ExploreSyncWorker.kt
+++ b/wallet/src/de/schildbach/wallet/ExploreSyncWorker.kt
@@ -18,14 +18,13 @@ package de.schildbach.wallet
 
 import android.annotation.SuppressLint
 import android.content.Context
+import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.google.common.base.Stopwatch
 import com.google.firebase.FirebaseNetworkException
-import dagger.hilt.EntryPoint
-import dagger.hilt.InstallIn
-import dagger.hilt.android.EntryPointAccessors
-import dagger.hilt.components.SingletonComponent
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.dash.wallet.common.services.analytics.AnalyticsService
@@ -33,30 +32,15 @@ import org.dash.wallet.features.exploredash.repository.ExploreRepository
 import org.slf4j.LoggerFactory
 import java.util.*
 
-class ExploreSyncWorker constructor(val appContext: Context, workerParams: WorkerParameters) :
-    CoroutineWorker(appContext, workerParams) {
-
+@HiltWorker
+class ExploreSyncWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val analytics: AnalyticsService,
+    private val exploreRepository: ExploreRepository
+): CoroutineWorker(appContext, workerParams) {
     companion object {
         private val log = LoggerFactory.getLogger(ExploreSyncWorker::class.java)
-    }
-
-    private val exploreRepository by lazy {
-        entryPoint.exploreRepository()
-    }
-
-    private val analytics by lazy {
-        entryPoint.analytics()
-    }
-
-    @EntryPoint
-    @InstallIn(SingletonComponent::class)
-    interface ExploreSyncWorkerEntryPoint {
-        fun exploreRepository(): ExploreRepository
-        fun analytics(): AnalyticsService
-    }
-
-    private val entryPoint by lazy {
-        EntryPointAccessors.fromApplication(appContext, ExploreSyncWorkerEntryPoint::class.java)
     }
 
     @SuppressLint("CommitPrefEdits")

--- a/wallet/src/de/schildbach/wallet/payments/SendCoinsTaskRunner.kt
+++ b/wallet/src/de/schildbach/wallet/payments/SendCoinsTaskRunner.kt
@@ -43,7 +43,7 @@ class SendCoinsTaskRunner @Inject constructor(
 
     override suspend fun sendCoins(address: Address, amount: Coin, constrainInputsTo: Address?): Transaction {
         val wallet = walletApplication.wallet ?: throw RuntimeException("this method can't be used before creating the wallet")
-        ensureContext(wallet.context)
+        Context.propagate(wallet.context)
         val sendRequest = createSendRequest(address, amount, constrainInputsTo)
         val scryptIterationsTarget = walletApplication.scryptIterationsTarget()
 
@@ -67,7 +67,7 @@ class SendCoinsTaskRunner @Inject constructor(
         exchangeRate: ExchangeRate? = null,
         txCompleted: Boolean = false
     ): Transaction = withContext(Dispatchers.IO) {
-        ensureContext(wallet.context)
+        Context.propagate(wallet.context)
 
         val securityGuard = SecurityGuard()
         val password = securityGuard.retrievePassword()
@@ -135,13 +135,5 @@ class SendCoinsTaskRunner @Inject constructor(
 
         // Hand back the (possibly changed) encryption key.
         return key
-    }
-
-    private fun ensureContext(context: Context) {
-        Context.propagate(context)
-
-        if (Looper.myLooper() == null) {
-            Looper.prepare()
-        }
     }
 }

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -178,8 +178,9 @@ public class BlockchainServiceImpl extends LifecycleService implements Blockchai
             APPWIDGET_THROTTLE_MS) {
 
         // TODO: don't filter out notifications for withdrawals from CrowdNode
-        private final IgnoreAddressTxFilter ignoreCrowdNodeFilter =
-                new IgnoreAddressTxFilter(CrowdNodeConstants.INSTANCE.getCROWDNODE_ADDRESS());
+        private final IgnoreAddressTxFilter ignoreCrowdNodeFilter = new IgnoreAddressTxFilter(
+                CrowdNodeConstants.INSTANCE.getCrowdNodeAddress(Constants.NETWORK_PARAMETERS)
+        );
 
         @Override
         public void onThrottledWalletChanged() {

--- a/wallet/src/de/schildbach/wallet/transactions/WalletBalanceObserver.kt
+++ b/wallet/src/de/schildbach/wallet/transactions/WalletBalanceObserver.kt
@@ -17,7 +17,6 @@
 
 package de.schildbach.wallet.transactions
 
-import android.util.Log
 import de.schildbach.wallet.Constants
 import de.schildbach.wallet.util.ThrottlingWalletChangeListener
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/wallet/src/de/schildbach/wallet/transactions/WalletTransactionObserver.kt
+++ b/wallet/src/de/schildbach/wallet/transactions/WalletTransactionObserver.kt
@@ -17,7 +17,8 @@
 
 package de.schildbach.wallet.transactions
 
-import de.schildbach.wallet.Constants
+import android.os.Looper
+import android.util.Log
 import de.schildbach.wallet.util.ThrottlingWalletChangeListener
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
@@ -33,7 +34,11 @@ import org.dash.wallet.common.transactions.TransactionFilter
 @ExperimentalCoroutinesApi
 class WalletTransactionObserver(private val wallet: Wallet) {
     fun observe(vararg filters: TransactionFilter): Flow<Transaction> = callbackFlow {
-        Context.propagate(Context(Constants.NETWORK_PARAMETERS)) // TODO: use wallet.context instead?
+        Context.propagate(wallet.context)
+
+        if (Looper.myLooper() == null) {
+            Looper.prepare()
+        }
 
         val walletChangeListener = object : ThrottlingWalletChangeListener() {
             override fun onThrottledWalletChanged() { }

--- a/wallet/src/de/schildbach/wallet/ui/AboutActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/AboutActivity.kt
@@ -27,7 +27,6 @@ import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import com.google.firebase.installations.FirebaseInstallations
 import dagger.hilt.android.AndroidEntryPoint
-import de.schildbach.wallet.ExploreSyncWorker
 import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet.util.Toast
 import de.schildbach.wallet_test.BuildConfig

--- a/wallet/src/de/schildbach/wallet/ui/notifications/NotificationManagerWrapper.kt
+++ b/wallet/src/de/schildbach/wallet/ui/notifications/NotificationManagerWrapper.kt
@@ -17,6 +17,7 @@
 
 package de.schildbach.wallet.ui.notifications
 
+import android.app.Notification
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
@@ -36,11 +37,25 @@ class NotificationManagerWrapper @Inject constructor(
         Context.NOTIFICATION_SERVICE
     ) as NotificationManager
 
-    override fun showNotification(tag: String, message: String, intent: Intent?) {
+    override fun showNotification(
+        tag: String,
+        message: String,
+        isOngoing: Boolean,
+        intent: Intent?
+    ) {
+        val notification = buildNotification(message, isOngoing, intent)
+        notificationManager.notify(tag.hashCode(), notification)
+    }
+
+    override fun buildNotification(
+        message: String,
+        isOngoing: Boolean,
+        intent: Intent?
+    ): Notification {
         val appName = appContext.getString(R.string.app_name)
         val notification: NotificationCompat.Builder = NotificationCompat.Builder(
             appContext,
-            Constants.NOTIFICATION_CHANNEL_ID_GENERIC
+            if (isOngoing) Constants.NOTIFICATION_CHANNEL_ID_ONGOING else Constants.NOTIFICATION_CHANNEL_ID_GENERIC
         ).setSmallIcon(R.drawable.ic_dash_d_white_bottom)
             .setTicker(appName)
             .setContentTitle(appName)
@@ -54,6 +69,6 @@ class NotificationManagerWrapper @Inject constructor(
             notification.setContentIntent(pendingIntent).setAutoCancel(true)
         }
 
-        notificationManager.notify(tag.hashCode(), notification.build())
+        return notification.build()
     }
 }

--- a/wallet/src/de/schildbach/wallet/ui/staking/StakingActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/staking/StakingActivity.kt
@@ -17,6 +17,7 @@
 
 package de.schildbach.wallet.ui.staking
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -64,6 +65,9 @@ class StakingActivity : LockScreenActivity() {
             }
         }
 
+        val intent = Intent(this, StakingActivity::class.java)
+        viewModel.setNotificationIntent(intent)
+
         setContentView(binding.root)
     }
 
@@ -92,5 +96,15 @@ class StakingActivity : LockScreenActivity() {
             }
 
         navController.graph = navGraph
+    }
+
+    override fun onPause() {
+        super.onPause()
+        viewModel.changeNotifyWhenDone(true)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.changeNotifyWhenDone(false)
     }
 }


### PR DESCRIPTION
We want to continue CrowdNode signup process even if the user closed the app.

## Issue being fixed or feature implemented
- Running signup in a CoroutineWorker with `setForeground` to assure that we the worker can broadcast transactions.
- `HiltWorkerFactory` is added to simplify DI in workers and to have Wallet in line with DashPay.
- Fixed the "Insufficient money" issue for the top-up transaction by transferring only 0.009 Dash out of the minimum required 0.01.
- Broadened the conditions for the `LockedTransaction` filter to fix the stuck signup process.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
