### PR TITLE
[NMA-1045] (Liquid) Support popup on 'kyc' event

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/ui/dialogs/AdaptiveDialog.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/dialogs/AdaptiveDialog.kt
@@ -62,8 +62,8 @@ class AdaptiveDialog(@LayoutRes private val layout: Int): DialogFragment() {
                 positiveButtonText
             )
         }
-        // not usable from Java
-        fun new(
+
+        fun create(
             @DrawableRes icon: Int,
             title: String,
             message: String,

--- a/common/src/main/res/drawable/ic_error_red.xml
+++ b/common/src/main/res/drawable/ic_error_red.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2022 Dash Core Group.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path
+        android:pathData="M50,50m-50,0a50,50 0,1 1,100 0a50,50 0,1 1,-100 0"
+        android:strokeAlpha="0.1"
+        android:fillColor="#E85C4A"
+        android:fillAlpha="0.1"/>
+    <path
+        android:pathData="m49.988,80c3.288,0 6.428,-0.51 9.42,-1.531c2.992,-1.021 5.738,-2.45 8.239,-4.289c2.501,-1.839 4.675,-4.009 6.521,-6.51c1.847,-2.501 3.28,-5.247 4.301,-8.239c1.021,-2.992 1.531,-6.132 1.531,-9.42c0,-3.288 -0.51,-6.428 -1.531,-9.42c-1.021,-2.992 -2.454,-5.738 -4.301,-8.239c-1.847,-2.501 -4.02,-4.675 -6.521,-6.521c-2.501,-1.847 -5.247,-3.28 -8.239,-4.301c-2.992,-1.021 -6.14,-1.531 -9.443,-1.531c-3.288,0 -6.424,0.51 -9.408,1.531c-2.984,1.021 -5.727,2.454 -8.228,4.301c-2.501,1.847 -4.675,4.02 -6.521,6.521c-1.847,2.501 -3.276,5.247 -4.289,8.239c-1.013,2.992 -1.519,6.132 -1.519,9.42c0,3.288 0.51,6.428 1.531,9.42c1.021,2.992 2.45,5.738 4.289,8.239c1.839,2.501 4.009,4.671 6.509,6.51c2.501,1.839 5.247,3.268 8.239,4.289c2.992,1.021 6.132,1.531 9.42,1.531z"
+        android:fillColor="#E85C4A"/>
+    <path
+        android:pathData="m39.213,62.493c-0.483,0 -0.884,-0.16 -1.204,-0.479c-0.319,-0.319 -0.479,-0.713 -0.479,-1.18c0,-0.468 0.171,-0.865 0.514,-1.192l9.583,-9.606l-9.583,-9.583c-0.343,-0.343 -0.514,-0.748 -0.514,-1.215c0,-0.468 0.16,-0.857 0.479,-1.169c0.319,-0.312 0.721,-0.467 1.204,-0.467c0.468,0 0.865,0.179 1.192,0.538l9.607,9.56l9.583,-9.583c0.358,-0.358 0.764,-0.538 1.215,-0.538c0.467,0 0.865,0.16 1.192,0.479c0.327,0.319 0.491,0.705 0.491,1.157c0,0.468 -0.171,0.873 -0.514,1.215l-9.63,9.606l9.607,9.583c0.343,0.358 0.514,0.763 0.514,1.215c0,0.468 -0.164,0.861 -0.491,1.18c-0.327,0.319 -0.725,0.479 -1.192,0.479c-0.452,0 -0.873,-0.179 -1.262,-0.538l-9.513,-9.56l-9.536,9.56c-0.374,0.358 -0.795,0.538 -1.262,0.538z"
+        android:fillColor="#ffffff"/>
+</vector>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="network_unavailable_balance_not_accurate">The balance may not be accurate because of the lost connection</string>
     <string name="fiat_balance_with_currency" translatable="false">%s %s</string>
     <string name="zero_fiat_balance_with_currency" translatable="false">%s 0.00</string>
+    <string name="something_wrong">Something went wrong</string>
 
     <!-- Local Currency List: GGP -->
     <string name="currency_GGP">Guernsey Pound</string>

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/extensions/LocationFragmentExt.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/extensions/LocationFragmentExt.kt
@@ -89,7 +89,7 @@ suspend fun Fragment.showPermissionExplainerDialog(exploreTopic: ExploreTopic): 
         R.string.explore_atm_location_explainer_message
     }
 
-    val dialog = AdaptiveDialog.new(
+    val dialog = AdaptiveDialog.create(
         R.drawable.ic_location,
         getString(title),
         getString(message),

--- a/liquid-integration/src/main/java/org/dash/wallet/integration/liquid/ui/BuyDashWithCreditCardActivity.kt
+++ b/liquid-integration/src/main/java/org/dash/wallet/integration/liquid/ui/BuyDashWithCreditCardActivity.kt
@@ -12,11 +12,11 @@ import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.MenuItem
 import android.view.View
 import android.webkit.*
 import android.widget.Toast
-import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
@@ -32,6 +32,7 @@ import org.dash.wallet.common.services.analytics.FirebaseAnalyticsServiceImpl
 import org.dash.wallet.common.ui.ConnectivityViewModel
 import org.dash.wallet.common.ui.NetworkUnavailableFragment
 import org.dash.wallet.common.ui.NetworkUnavailableFragmentViewModel
+import org.dash.wallet.common.ui.dialogs.AdaptiveDialog
 import org.dash.wallet.integration.liquid.R
 import org.dash.wallet.integration.liquid.data.LiquidClient
 import org.dash.wallet.integration.liquid.data.LiquidConstants
@@ -520,10 +521,16 @@ class BuyDashWithCreditCardActivity : InteractionAwareActivity() {
                                     widgetState = "verifying"
                                     onUserInteraction()
                                 }
+                                // liquid: EventData::{"event":"step_transition","data":{"new_step":"kyc","old_step":"quoting","formPercent":42,"meta":null}}
+                                "kyc" -> {
+                                    onUserInteraction()
+                                    showContactSupportDialog()
+                                }
                             }
                         }
                         // liquid: EventData::{"event":"ui_event","data":{"ui_event":"button_clicked","value":"next","target":"quote_view_next"}}
                         "ui_event" -> {
+
                             onUserInteraction()
                             val uiEvent = Gson().fromJson(eventData, UIEvent::class.java)
                             
@@ -606,6 +613,22 @@ class BuyDashWithCreditCardActivity : InteractionAwareActivity() {
         } else {
             log.info("liquid: onBackPressed: successful transaction was not made")
             finish()
+        }
+    }
+
+    private fun showContactSupportDialog() {
+        AdaptiveDialog.create(
+            R.drawable.ic_error_red,
+            getString(R.string.something_wrong),
+            getString(R.string.liquid_something_wrong_message),
+            getString(R.string.close),
+            getString(R.string.liquid_contact_support)
+        ).show(this) {
+            if (it == true) {
+                startActivity(Intent(Intent.ACTION_VIEW).apply {
+                    data = Uri.parse(getString(R.string.liquid_support_website))
+                })
+            }
         }
     }
 }

--- a/liquid-integration/src/main/java/org/dash/wallet/integration/liquid/ui/BuyDashWithCreditCardActivity.kt
+++ b/liquid-integration/src/main/java/org/dash/wallet/integration/liquid/ui/BuyDashWithCreditCardActivity.kt
@@ -530,7 +530,6 @@ class BuyDashWithCreditCardActivity : InteractionAwareActivity() {
                         }
                         // liquid: EventData::{"event":"ui_event","data":{"ui_event":"button_clicked","value":"next","target":"quote_view_next"}}
                         "ui_event" -> {
-
                             onUserInteraction()
                             val uiEvent = Gson().fromJson(eventData, UIEvent::class.java)
                             

--- a/liquid-integration/src/main/java/org/dash/wallet/integration/liquid/ui/BuyDashWithCryptoCurrencyActivity.kt
+++ b/liquid-integration/src/main/java/org/dash/wallet/integration/liquid/ui/BuyDashWithCryptoCurrencyActivity.kt
@@ -340,7 +340,7 @@ class BuyDashWithCryptoCurrencyActivity : InteractionAwareActivity() {
         );
     }
 
-    fun executeJavascriptInWebview(rawJavascript: String) {
+    private fun executeJavascriptInWebview(rawJavascript: String) {
         log.info("liquid: execute script: $rawJavascript")
         runOnUiThread {
             webview.evaluateJavascript(rawJavascript, null);

--- a/liquid-integration/src/main/java/org/dash/wallet/integration/liquid/ui/LiquidSplashActivity.kt
+++ b/liquid-integration/src/main/java/org/dash/wallet/integration/liquid/ui/LiquidSplashActivity.kt
@@ -276,8 +276,7 @@ class LiquidSplashActivity : InteractionAwareActivity() {
 
         val uri = Uri.parse(url)
 
-        CustomTabActivityHelper.openCustomTab(this, customTabsIntent, uri
-        ) { _, _ ->
+        CustomTabActivityHelper.openCustomTab(this, customTabsIntent, uri) { _, _ ->
             log.info("liquid: login failure because custom tabs is not available")
             log.info("liquid: using the web browser instead for $uri")
             val intent = Intent(Intent.ACTION_VIEW)

--- a/liquid-integration/src/main/java/org/dash/wallet/integration/liquid/ui/SellDashActivity.kt
+++ b/liquid-integration/src/main/java/org/dash/wallet/integration/liquid/ui/SellDashActivity.kt
@@ -270,7 +270,7 @@ class SellDashActivity : InteractionAwareActivity() {
         )
     }
 
-    fun executeJavascriptInWebview(rawJavascript: String) {
+    private fun executeJavascriptInWebview(rawJavascript: String) {
         log.info("liquid: execute script: $rawJavascript")
         runOnUiThread {
             webview.evaluateJavascript(rawJavascript, null);
@@ -377,6 +377,4 @@ class SellDashActivity : InteractionAwareActivity() {
             finish()
         }
     }
-
-
 }

--- a/liquid-integration/src/main/res/values/strings-liquid.xml
+++ b/liquid-integration/src/main/res/values/strings-liquid.xml
@@ -25,6 +25,8 @@
     <string name="buying_dash_not_supported_credit_cards">Buying Dash with a credit card is not supported in some countries.</string>
     <string name="buying_dash_not_supported_crypto">Buying Dash with cryptocurrency is not supported in some countries.</string>
     <string name="buying_dash_success_message">You can close this screen, your Dash will be sent to your wallet.</string>
+    <string name="liquid_contact_support">Contact Liquid Support</string>
+    <string name="liquid_something_wrong_message">Retry later or contact Liquid support center to solve the problem.</string>
 
     <string name="confirm">Confirm</string>
     <string name="card_fees">Card Fees</string>
@@ -57,4 +59,6 @@
     <string name="liquid">Liquid</string>
     <string name="transfer">Transfer</string>
     <string name="filter_by">Filtered By</string>
+
+    <string name="liquid_support_website" translatable="false">https://help.liquid.com</string>
 </resources>

--- a/wallet/src/de/schildbach/wallet/ui/SetPinActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SetPinActivity.kt
@@ -448,7 +448,7 @@ class SetPinActivity : InteractionAwareActivity() {
             title = R.string.set_pin_error_missing_wallet_title
             message = R.string.set_pin_error_missing_wallet_message
         }
-        val dialog = AdaptiveDialog.new(
+        val dialog = AdaptiveDialog.create(
             R.drawable.ic_error,
             getString(title),
             getString(message),


### PR DESCRIPTION
On the event
`EventData::{"event":"step_transition","data":{"new_step":"kyc","old_step":"quoting","formPercent":42,"meta":null}}`
We want to show a popup with a link to the Liquid support website.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->
<img src="https://user-images.githubusercontent.com/7733989/159731503-84600241-7412-4706-977c-ce7743ee0527.jpg"  width="300" />

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
