### PR TITLE
fix: finish onboarding if upgrading with unencrypted wallet

### DIFF
--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -7,6 +7,7 @@
     <string name="onboarding_load_wallet_error">Unable to load wallet!</string>
 
     <string name="set_pin_create_new_wallet">Create a New Wallet</string>
+    <string name="set_pin_upgrade_wallet">Upgrade Wallet</string>
     <string name="set_pin_restore_wallet">Restore Wallet</string>
     <string name="set_pin_enter_pin">Enter old PIN</string>
     <string name="set_pin_set_pin">Set PIN</string>

--- a/wallet/src/de/schildbach/wallet/ui/OnboardingActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/OnboardingActivity.kt
@@ -93,7 +93,6 @@ class OnboardingActivity : RestoreFromFileActivity() {
 
         viewModel = ViewModelProvider(this)[OnboardingViewModel::class.java]
 
-        initViewModel()
         if (walletApplication.walletFileExists()) {
             if (!walletApplication.wallet.isEncrypted) {
                 unencryptedFlow()

--- a/wallet/src/de/schildbach/wallet/ui/OnboardingActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/OnboardingActivity.kt
@@ -37,7 +37,6 @@ import de.schildbach.wallet.ui.security.SecurityGuard
 import de.schildbach.wallet_test.R
 import kotlinx.android.synthetic.main.activity_onboarding.*
 import kotlinx.android.synthetic.main.activity_onboarding_perm_lock.*
-import kotlinx.android.synthetic.main.activity_onboarding_invalid_wallet.*
 import org.dash.wallet.common.services.analytics.AnalyticsService
 import org.dash.wallet.common.ui.BaseAlertDialogBuilder
 import org.slf4j.LoggerFactory
@@ -47,6 +46,8 @@ private const val REGULAR_FLOW_TUTORIAL_REQUEST_CODE = 0
 const val SET_PIN_REQUEST_CODE = 1
 private const val RESTORE_PHRASE_REQUEST_CODE = 2
 private const val RESTORE_FILE_REQUEST_CODE = 3
+private const val UPGRADE_NONENCRYPTED_FLOW_TUTORIAL_REQUEST_CODE = 4
+
 
 @AndroidEntryPoint
 class OnboardingActivity : RestoreFromFileActivity() {
@@ -85,8 +86,6 @@ class OnboardingActivity : RestoreFromFileActivity() {
                 ResetWalletDialog.newInstance().show(supportFragmentManager, "reset_wallet_dialog")
             }
             return
-        } else if (walletApplication.isWalletUpgradedtoBIP44 && !walletApplication.wallet.isEncrypted) {
-            unencryptedFlow()
         }
 
         setContentView(R.layout.activity_onboarding)
@@ -94,16 +93,16 @@ class OnboardingActivity : RestoreFromFileActivity() {
 
         viewModel = ViewModelProvider(this)[OnboardingViewModel::class.java]
 
-
+        initViewModel()
         if (walletApplication.walletFileExists()) {
-            if (walletApplication.isWalletUpgradedtoBIP44) {
-                if (walletApplication.wallet.isEncrypted) {
+            if (!walletApplication.wallet.isEncrypted) {
+                unencryptedFlow()
+            } else {
+                if (walletApplication.isWalletUpgradedtoBIP44) {
                     regularFlow()
                 } else {
-                    unencryptedFlow()
+                    upgradeToBIP44Flow()
                 }
-            } else {
-                upgradeToBIP44Flow()
             }
         } else {
             if (walletApplication.wallet == null) {
@@ -122,23 +121,21 @@ class OnboardingActivity : RestoreFromFileActivity() {
     // This is due to a wallet being created in an invalid way
     // such that the wallet is not encrypted
     private fun unencryptedFlow() {
-        log.info("the wallet is not encrypted")
-        analytics.logError(
-            Exception("the wallet is not encrypted / OnboardingActivity"),
-            "no other details are available without the user submitting a report"
-        )
-
-        setContentView(R.layout.activity_onboarding_invalid_wallet)
-        hideSlogan()
-
-        unencrypted_close_app.setOnClickListener {
-            finish()
+        log.info("the wallet is not encrypted -- the wallet will be upgraded")
+        if (walletApplication.configuration.v7TutorialCompleted) {
+            upgradeUnencryptedWallet()
+        } else {
+            startActivityForResult(Intent(this, WelcomeActivity::class.java),
+                UPGRADE_NONENCRYPTED_FLOW_TUTORIAL_REQUEST_CODE)
+            overridePendingTransition(R.anim.fade_in, R.anim.fade_out)
         }
-        unencrypted_contact_support.setOnClickListener {
-            val alertDialog = ReportIssueDialogBuilder.createReportIssueDialog(
-                this@OnboardingActivity, walletApplication).buildAlertDialog()
-            alertDialog.show()
+    }
+
+    private fun upgradeUnencryptedWallet() {
+        viewModel.finishUnecryptedWalletUpgradeAction.observe(this) {
+            startActivityForResult(SetPinActivity.createIntent(application, R.string.set_pin_upgrade_wallet, upgradingWallet = true), SET_PIN_REQUEST_CODE)
         }
+        viewModel.upgradeUnencryptedWallet()
     }
 
     private fun upgradeToBIP44Flow() {
@@ -214,9 +211,9 @@ class OnboardingActivity : RestoreFromFileActivity() {
                 showIcon = true
             }.buildAlertDialog().show()
         })
-        viewModel.startActivityAction.observe(this, Observer {
-            startActivityForResult(it, SET_PIN_REQUEST_CODE)
-        })
+        viewModel.finishCreateNewWalletAction.observe(this) {
+            startActivityForResult(SetPinActivity.createIntent(application, R.string.set_pin_create_new_wallet), SET_PIN_REQUEST_CODE)
+        }
     }
 
     private fun showButtonsDelayed() {
@@ -249,6 +246,8 @@ class OnboardingActivity : RestoreFromFileActivity() {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == REGULAR_FLOW_TUTORIAL_REQUEST_CODE) {
             upgradeOrStartMainActivity()
+        } else if (requestCode == UPGRADE_NONENCRYPTED_FLOW_TUTORIAL_REQUEST_CODE) {
+            upgradeUnencryptedWallet()
         } else if ((requestCode == SET_PIN_REQUEST_CODE || requestCode == RESTORE_PHRASE_REQUEST_CODE) && resultCode == Activity.RESULT_OK) {
             finish()
         }

--- a/wallet/src/de/schildbach/wallet/ui/OnboardingViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/OnboardingViewModel.kt
@@ -19,11 +19,10 @@ package de.schildbach.wallet.ui
 import android.app.Application
 import android.content.Intent
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
 import de.schildbach.wallet.Constants
 import de.schildbach.wallet.WalletApplication
-import de.schildbach.wallet.util.WalletUtils
-import de.schildbach.wallet_test.R
-import org.bitcoinj.crypto.MnemonicCode
+import kotlinx.coroutines.launch
 import org.bitcoinj.crypto.MnemonicException
 import org.bitcoinj.wallet.Wallet
 import org.slf4j.LoggerFactory
@@ -36,7 +35,8 @@ class OnboardingViewModel(application: Application) : AndroidViewModel(applicati
 
     internal val showToastAction = SingleLiveEvent<String>()
     internal val showRestoreWalletFailureAction = SingleLiveEvent<MnemonicException>()
-    internal val startActivityAction = SingleLiveEvent<Intent>()
+    internal val finishCreateNewWalletAction = SingleLiveEvent<Unit>()
+    internal val finishUnecryptedWalletUpgradeAction = SingleLiveEvent<Unit>()
 
     fun createNewWallet() {
         walletApplication.initEnvironmentIfNeeded()
@@ -44,6 +44,19 @@ class OnboardingViewModel(application: Application) : AndroidViewModel(applicati
         log.info("successfully created new wallet")
         walletApplication.wallet = wallet
         walletApplication.configuration.armBackupSeedReminder()
-        startActivityAction.call(SetPinActivity.createIntent(getApplication(), R.string.set_pin_create_new_wallet))
+        finishCreateNewWalletAction.call(Unit)
+    }
+
+    fun upgradeUnencryptedWallet() {
+        log.info("upgrading previously created wallet from version 6 or before")
+        viewModelScope.launch {
+            // Does this wallet use BIP44
+            if (!walletApplication.isWalletUpgradedtoBIP44) {
+                walletApplication.wallet.addKeyChain(Constants.BIP44_PATH)
+            }
+            walletApplication.configuration.armBackupSeedReminder()
+
+            finishUnecryptedWalletUpgradeAction.call(Unit)
+        }
     }
 }

--- a/wallet/src/de/schildbach/wallet/ui/SetPinActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SetPinActivity.kt
@@ -135,27 +135,31 @@ class SetPinActivity : InteractionAwareActivity() {
 
         walletApplication = application as WalletApplication
 
-        if (walletApplication.wallet.isEncrypted) {
-            if (initialPin != null) {
-                if (changePin) {
-                    viewModel.oldPinCache = initialPin
-                    setState(State.SET_PIN)
-                } else {
-                    viewModel.decryptKeys(initialPin)
-                }
-            } else {
-                if (changePin) {
-                    if (pinRetryController.isLocked) {
-                        setState(State.LOCKED)
+        if (walletApplication.wallet == null) {
+            showErrorDialog(false, NullPointerException("wallet is null in SetPinActivity"))
+        } else {
+            if (walletApplication.wallet.isEncrypted) {
+                if (initialPin != null) {
+                    if (changePin) {
+                        viewModel.oldPinCache = initialPin
+                        setState(State.SET_PIN)
                     } else {
-                        setState(State.CHANGE_PIN)
+                        viewModel.decryptKeys(initialPin)
                     }
                 } else {
-                    setState(State.DECRYPT)
+                    if (changePin) {
+                        if (pinRetryController.isLocked) {
+                            setState(State.LOCKED)
+                        } else {
+                            setState(State.CHANGE_PIN)
+                        }
+                    } else {
+                        setState(State.DECRYPT)
+                    }
                 }
+            } else {
+                seed = walletApplication.wallet.keyChainSeed.mnemonicCode!!
             }
-        } else {
-            seed = walletApplication.wallet.keyChainSeed.mnemonicCode!!
         }
     }
 
@@ -363,6 +367,7 @@ class SetPinActivity : InteractionAwareActivity() {
                                     android.widget.Toast.LENGTH_LONG).show()
                             }
                         } else {
+                            showErrorDialog(true, it.exception)
                             setState(State.CONFIRM_PIN)
                         }
                     }
@@ -437,7 +442,6 @@ class SetPinActivity : InteractionAwareActivity() {
         })
     }
 
-    @Deprecated("This error dialog may no longer be useful")
     private fun showErrorDialog(isEncryptingError: Boolean, exception: Throwable?) {
         if (exception != null) {
             analytics.logError(exception, "SetPinActivity Error")

--- a/wallet/src/de/schildbach/wallet/ui/SetPinViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SetPinViewModel.kt
@@ -45,9 +45,9 @@ class SetPinViewModel(application: Application) : AndroidViewModel(application) 
         return pin.joinToString("")
     }
 
-    fun savePinAndEncrypt() {
+    fun savePinAndEncrypt(initialize: Boolean) {
         val pin = getPinAsString()
-        savePinAndEncrypt(pin, true)
+        savePinAndEncrypt(pin, initialize)
     }
 
     fun savePinAndEncrypt(pin: String, initialize: Boolean) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
v6 and v5 wallets will go to the Set Pin screen during the upgrade process if the app doesn't have a PIN set.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
