### PR TITLE
fix: initializing MainViewModel earlier in WalletActivity

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -141,6 +141,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
         application = getWalletApplication();
         config = application.getConfiguration();
         wallet = application.getWallet();
+        viewModel = new ViewModelProvider(this).get(MainActivityViewModel.class);
 
         setContentViewFooter(R.layout.home_activity);
         setSupportActionBar(findViewById(R.id.toolbar));
@@ -185,7 +186,9 @@ public final class WalletActivity extends AbstractBindServiceActivity
             }
         });
 
-        initViewModel();
+        viewModel.getOnTransactionsUpdated().observe(this, aVoid -> {
+            refreshShortcutBar();
+        });
     }
 
     @Override
@@ -199,13 +202,6 @@ public final class WalletActivity extends AbstractBindServiceActivity
 
     private void initView() {
         initShortcutActions();
-    }
-
-    private void initViewModel() {
-        viewModel = new ViewModelProvider(this).get(MainActivityViewModel.class);
-        viewModel.getOnTransactionsUpdated().observe(this, aVoid -> {
-            refreshShortcutBar();
-        });
     }
 
     private void initShortcutActions() {


### PR DESCRIPTION
To avoid NRE in the `onCreate` code, the viewModel should be initialized early on.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
