### PR TITLE
fix: autologout in Exchange integrations (NMA-1307)

### DIFF
--- a/wallet/src/de/schildbach/wallet/AutoLogout.java
+++ b/wallet/src/de/schildbach/wallet/AutoLogout.java
@@ -79,8 +79,10 @@ public class AutoLogout {
     }
 
     public void startTimer() {
-        lockTimerClock.postDelayed(timerTask, LOCK_TIMER_TICK_MS);
-        timerActive = true;
+        if (!timerActive) {
+            lockTimerClock.postDelayed(timerTask, LOCK_TIMER_TICK_MS);
+            timerActive = true;
+        }
     }
 
     private final Runnable timerTask = new Runnable() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
After entering the Liquid or Uphold screens, the autologout timer was accelerated.

Each time `startTimer` was called, a new timer was created.  The fix is to prevent creating a new timer if one is active.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->
None
## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
