### PR TITLE
[NMA-1303] Fix: 'not assosiated with a fragment manager' crash

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/ui/dialogs/AdaptiveDialog.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/dialogs/AdaptiveDialog.kt
@@ -72,7 +72,10 @@ open class AdaptiveDialog(@LayoutRes private val layout: Int): DialogFragment() 
             val dialog = progress(message)
             dialog.show(activity) { }
             val result = action.invoke()
-            dialog.dismiss()
+
+            if (dialog.activity != null && dialog.isAdded) {
+                dialog.dismissAllowingStateLoss()
+            }
 
             return result
         }


### PR DESCRIPTION
A progress dialog is sometimes crashing if dismissed while not attached to an activity.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
