### PR TITLE
[NMA-1312] (CrowdNode) Fix for the invalid online state

### DIFF
--- a/common/src/main/res/values/colors.xml
+++ b/common/src/main/res/values/colors.xml
@@ -78,7 +78,7 @@
     <color name="button_ripple_color">#1f000000</color>
     <color name="disabled_button_bg">#eeeeee</color>
     <color name="max_button_bg">#ebebeb</color>
-    <color name="text_highlight_blue_bg">#ebf6fd</color>
+    <color name="text_highlight_blue_bg">#14008DE4</color>
     <color name="ultra_light_gray">#f5f6f7</color>
     <color name="warning_yellow">#fff9ed</color>
     <color name="input_error_background">#1AE85C4A</color>

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/model/ApiStatuses.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/model/ApiStatuses.kt
@@ -17,7 +17,9 @@
 
 package org.dash.wallet.integrations.crowdnode.model
 
-// Order matters
+// Order matters. If modifications are required,
+// it's better make this initializable with a value
+// that maps to the old order value (see ApiCode)
 enum class SignUpStatus {
     NotStarted,
     FundingWallet,
@@ -28,7 +30,9 @@ enum class SignUpStatus {
     LinkedOnline
 }
 
-// Order matters
+// Order matters. If modifications are required,
+// it's better make this initializable with a value
+// that maps to the old order value (see ApiCode)
 enum class OnlineAccountStatus {
     None,
     Linking,

--- a/integrations/crowdnode/src/main/res/layout/fragment_portal.xml
+++ b/integrations/crowdnode/src/main/res/layout/fragment_portal.xml
@@ -113,7 +113,7 @@
                 android:id="@+id/deposit_btn"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:foreground="?attr/selectableItemBackground"
+                android:background="?attr/selectableItemBackground"
                 android:clickable="true"
                 android:focusable="true"
                 android:paddingTop="21dp"

--- a/integrations/crowdnode/src/main/res/values/styles.xml
+++ b/integrations/crowdnode/src/main/res/values/styles.xml
@@ -23,7 +23,7 @@
 
     <style name="TextHighlightBlueTheme">
         <item name="backgroundColor">@color/text_highlight_blue_bg</item>
-        <item name="strokeColor">@color/text_highlight_blue_bg</item>
+        <item name="strokeColor">@android:color/transparent</item>
         <item name="cornerRadius">8dp</item>
     </style>
 


### PR DESCRIPTION
There is a problem with 7.5.0 (beta) -> 7.5.1 upgrade scenario: because of the changes in ApiStatuses, the old online status is restored into a wrong value.

## Issue being fixed or feature implemented
Added a check for this specific case + some tests.
The base `bugfix-crowdnode-7.5.2` branch is checked out of 7.5.1 tag. We can release it as a hotfix with some other possible fixes.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [x] I have added or updated relevant unit/integration/functional/e2e tests
