### PR TITLE
[NMA-1318] fix: restoring CrowdNode status even when already initialized

### DIFF
--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/api/CrowdNodeApi.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/api/CrowdNodeApi.kt
@@ -65,6 +65,7 @@ interface CrowdNodeApi {
     var notificationIntent: Intent?
     var showNotificationOnResult: Boolean
 
+    fun restoreStatus()
     fun persistentSignUp(accountAddress: Address)
     suspend fun signUp(accountAddress: Address)
     suspend fun deposit(amount: Coin, emptyWallet: Boolean, checkBalanceConditions: Boolean): Boolean
@@ -450,7 +451,7 @@ class CrowdNodeApiAggregator @Inject constructor(
         config.clearAll()
     }
 
-    private fun restoreStatus() {
+    override fun restoreStatus() {
         if (signUpStatus.value == SignUpStatus.NotStarted) {
             log.info("restoring CrowdNode status")
 

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/CrowdNodeViewModel.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/CrowdNodeViewModel.kt
@@ -177,6 +177,10 @@ class CrowdNodeViewModel @Inject constructor(
         navigationCallback.postValue(NavigationRequest.SendReport)
     }
 
+    fun recheckState() {
+        crowdNodeApi.restoreStatus()
+    }
+
     fun signUp() {
         crowdNodeApi.persistentSignUp(_accountAddress.value!!)
     }

--- a/wallet/src/de/schildbach/wallet/ui/staking/StakingActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/staking/StakingActivity.kt
@@ -126,8 +126,11 @@ class StakingActivity : LockScreenActivity() {
         val navController = navHostFragment.navController
         val navGraph = navController.navInflater.inflate(R.navigation.nav_crowdnode)
 
+        viewModel.recheckState()
+        val status = viewModel.signUpStatus
+
         navGraph.startDestination =
-            when (viewModel.signUpStatus) {
+            when (status) {
                 SignUpStatus.LinkedOnline, SignUpStatus.Finished -> R.id.crowdNodePortalFragment
                 SignUpStatus.NotStarted -> {
                     val isInfoShown = runBlocking { viewModel.getIsInfoShown() }


### PR DESCRIPTION
If `CrowdNodeApi` was already initialized, it does not restore the correct sign-up status after the wallet wipe.

<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
Triggering sign-up status restore manually when needed.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
