### PR TITLE
fix: reverting transaction total amount + fee changes

### DIFF
--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/transactions/FullCrowdNodeSignUpTxSet.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/transactions/FullCrowdNodeSignUpTxSet.kt
@@ -86,11 +86,7 @@ open class FullCrowdNodeSignUpTxSet(
 
         for (tx in transactions) {
             val value = tx.getValue(bag)
-            val isSent = value.signum() < 0
-            val fee = tx.fee
-            val removeFee = isSent && fee != null && !fee.isZero
-
-            result = result.add(if (removeFee) value.plus(fee) else value)
+            result = result.add(value)
         }
 
         return result

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -175,7 +175,7 @@ android {
     defaultConfig {
         minSdkVersion 23
         targetSdkVersion 30
-        versionCode project.hasProperty('versionCode') ? project.property('versionCode') as int : 70520
+        versionCode project.hasProperty('versionCode') ? project.property('versionCode') as int : 70521
         versionName project.hasProperty('versionName') ? project.property('versionName') : "7.5.2"
         multiDexEnabled true
         generatedDensities = ['hdpi', 'xhdpi']

--- a/wallet/src/de/schildbach/wallet/ui/transactions/TransactionResultViewBinder.kt
+++ b/wallet/src/de/schildbach/wallet/ui/transactions/TransactionResultViewBinder.kt
@@ -161,16 +161,10 @@ class TransactionResultViewBinder(
 
         dashAmount.setFormat(dashFormat)
         //For displaying purposes only
-        val amount = if (isSent && isFeeAvailable(tx.fee)) {
-            value.plus(tx.fee)
+        if (value.isNegative) {
+            dashAmount.setAmount(value.negate())
         } else {
-            value
-        }
-
-        if (amount.isNegative) {
-            dashAmount.setAmount(amount.negate())
-        } else {
-            dashAmount.setAmount(amount)
+            dashAmount.setAmount(value)
         }
 
         if (isFeeAvailable(tx.fee)) {
@@ -221,7 +215,7 @@ class TransactionResultViewBinder(
                 transactionTitle.setTextColor(ContextCompat.getColor(ctx, R.color.dash_blue))
                 transactionTitle.text = ctx.getText(R.string.transaction_details_amount_sent)
                 transactionAmountSignal.text = "-"
-                transactionAmountSignal.isVisible = !TransactionUtils.isEntirelySelf(tx, wallet)
+                transactionAmountSignal.isVisible = true
             } else {
                 checkIcon.setImageResource(R.drawable.ic_transaction_received)
                 transactionTitle.setTextColor(ContextCompat.getColor(ctx, R.color.system_green))


### PR DESCRIPTION
During the development of the new Transaction Details screen, the logic for displaying the total amount was changed to show the amount only.
We want to revert that to show the amount + fee as it is now in production.
CrowdNode total amount calculation will also include fees.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
