### PR TITLE
[NMA-1324] fix: updating CrowdNode account address in viewModel after recheckState

### DIFF
--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/CrowdNodeViewModel.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/CrowdNodeViewModel.kt
@@ -154,11 +154,6 @@ class CrowdNodeViewModel @Inject constructor(
                 }
             }
             .launchIn(viewModelScope)
-
-        viewModelScope.launch {
-            _accountAddress.value = getOrCreateAccountAddress()
-            crowdNodeApi.refreshBalance()
-        }
     }
     
     fun backupPassphrase() {
@@ -179,6 +174,8 @@ class CrowdNodeViewModel @Inject constructor(
 
     suspend fun recheckState() {
         crowdNodeApi.restoreStatus()
+        _accountAddress.value = getOrCreateAccountAddress()
+        crowdNodeApi.refreshBalance()
     }
 
     fun signUp() {

--- a/integrations/crowdnode/src/test/java/org/dash/wallet/integrations/crowdnode/CrowdNodeViewModelTest.kt
+++ b/integrations/crowdnode/src/test/java/org/dash/wallet/integrations/crowdnode/CrowdNodeViewModelTest.kt
@@ -18,6 +18,7 @@
 package org.dash.wallet.integrations.crowdnode
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -110,6 +111,26 @@ class CrowdNodeViewModelTest {
             val viewModel = CrowdNodeViewModel(globalConfig, mock(), walletData, api, mock(), exchangeRatesMock, mock())
             viewModel.deposit(partial, false)
             verify(api).deposit(partial, emptyWallet = false, checkBalanceConditions = false)
+        }
+    }
+
+    @Test
+    fun recheckState_accountAddressIsSame() {
+        runBlocking {
+            api.stub {
+                onBlocking { restoreStatus() } doReturn Unit
+                on { accountAddress } doReturn null
+            }
+            val viewModel = CrowdNodeViewModel(globalConfig, mock(), walletData, api, mock(), exchangeRatesMock, mock())
+            val address = Address.fromBase58(TestNet3Params.get(), "yjMvPFucZWPZXKBaEDxHzZrm5Px44UhgJs")
+            api.stub {
+                on { accountAddress } doReturn address
+            }
+
+            viewModel.recheckState()
+
+            verify(api).restoreStatus()
+            assertEquals(address, viewModel.accountAddress.value)
         }
     }
 }

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -175,7 +175,7 @@ android {
     defaultConfig {
         minSdkVersion 23
         targetSdkVersion 30
-        versionCode project.hasProperty('versionCode') ? project.property('versionCode') as int : 70521
+        versionCode project.hasProperty('versionCode') ? project.property('versionCode') as int : 70522
         versionName project.hasProperty('versionName') ? project.property('versionName') : "7.5.2"
         multiDexEnabled true
         generatedDensities = ['hdpi', 'xhdpi']


### PR DESCRIPTION
Since we're calling `recheckState` now to rescan the status of CrowdNode, the viewModel state needs to be updated after it.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [x] I have added or updated relevant unit/integration/functional/e2e tests
