### PR TITLE
fix: setting desugaring library version to 1.1.5 to avoid crashes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,12 @@ buildscript {
         roomVersion = '2.3.0'
         lifecycleVersion = '2.3.1'
         navigationVersion = '2.5.1'
-        slf4jVersion = '1.7.32'
         jetpackVersion = '1.6.0'
         appCompatVersion = '1.3.1'
+
+        // Utils
+        slf4jVersion = '1.7.32'
+        desugaringLibraryVersion = '1.1.5'
 
         // UI
         materialVersion = "1.4.0"

--- a/integrations/crowdnode/build.gradle
+++ b/integrations/crowdnode/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.appcompat:appcompat:$appCompatVersion"
     implementation "org.dashj:dashj-core:$dashjVersion"
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.0'
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$desugaringLibraryVersion"
 
     // Architecture
     implementation "androidx.navigation:navigation-fragment-ktx:$navigationVersion"

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -29,7 +29,7 @@ dependencies {
         exclude(group: 'com.google.android', module: 'android')
     }
 
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.0'
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$desugaringLibraryVersion"
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 


### PR DESCRIPTION
There are some crashes related to `java.time` library, we need a correct version of desugaring library to avoid them.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
