### PR TITLE
fix: Error dialog on invalid QR code

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/ui/dialogs/AdaptiveDialog.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/dialogs/AdaptiveDialog.kt
@@ -32,6 +32,7 @@ import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.dash.wallet.common.R
 import org.dash.wallet.common.UserInteractionAwareCallback
@@ -197,7 +198,7 @@ open class AdaptiveDialog(@LayoutRes private val layout: Int): DialogFragment() 
     }
 
     fun show(activity: FragmentActivity, onResult: ((Boolean?) -> Unit)? = null) {
-        if (activity.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+        activity.lifecycleScope.launchWhenResumed {
             onResultListener = onResult
             show(activity.supportFragmentManager, "adaptive_dialog")
         }

--- a/common/src/main/java/org/dash/wallet/common/ui/dialogs/OffsetDialogFragment.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/dialogs/OffsetDialogFragment.kt
@@ -26,6 +26,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -94,7 +95,7 @@ open class OffsetDialogFragment : BottomSheetDialogFragment() {
     }
 
     fun show(activity: FragmentActivity) {
-        if (activity.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+        activity.lifecycleScope.launchWhenResumed {
             show(activity.supportFragmentManager, "offset_dialog")
         }
     }

--- a/wallet/src/de/schildbach/wallet/ui/main/WalletFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/main/WalletFragment.kt
@@ -271,7 +271,7 @@ class WalletFragment : Fragment(R.layout.home_content) {
                     R.drawable.ic_info_red,
                     getString(errorDialogTitleResId),
                     if (messageArgs.isNotEmpty()) {
-                        getString(messageResId, messageArgs)
+                        getString(messageResId, *messageArgs)
                     } else {
                         getString(messageResId)
                     },


### PR DESCRIPTION
Fix for https://support.dash.org/a/tickets/15911

This issue happens due to fixes for the `AdaptiveDialog` crashes. Because the state of activity isn't `RESUMED` by the time the app returns from the `ScanActivity`, the dialogs isn't shown.
We can replace this check with `activity.lifecycleScope.launchWhenResumed` which should work just as well for the crashes and resolve this issue.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
