### PR TITLE
fix: improve sync speeds for wallet restoration/rescan

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         kotlin_version = '1.6.10'
         coroutines_version = '1.5.2'
         ok_http_version = '4.9.1'
-        dashjVersion = '0.18.1'
+        dashjVersion = '0.18.2-SNAPSHOT'
         hiltVersion = '2.40.1'
         hiltWorkVersion = '1.0.0'
         workRuntimeVersion='2.7.1'

--- a/common/src/main/java/org/dash/wallet/common/WalletDataProvider.kt
+++ b/common/src/main/java/org/dash/wallet/common/WalletDataProvider.kt
@@ -51,6 +51,8 @@ interface WalletDataProvider {
 
     fun observeTransactions(vararg filters: TransactionFilter): Flow<Transaction>
 
+    fun observeTransactionsWithConfidence(vararg filters: TransactionFilter): Flow<Transaction>
+
     fun getTransactions(vararg filters: TransactionFilter): Collection<Transaction>
 
     fun wrapAllTransactions(vararg wrappers: TransactionWrapper): Collection<TransactionWrapper>

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/api/CrowdNodeBlockchainApi.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/api/CrowdNodeBlockchainApi.kt
@@ -51,7 +51,7 @@ open class CrowdNodeBlockchainApi @Inject constructor(
 
     suspend fun topUpAddress(accountAddress: Address, amount: Coin, emptyWallet: Boolean = false): Transaction {
         val topUpTx = paymentService.sendCoins(accountAddress, amount, null, emptyWallet)
-        return walletData.observeTransactions(LockedTransaction(topUpTx.txId)).first()
+        return walletData.observeTransactionsWithConfidence(LockedTransaction(topUpTx.txId)).first()
     }
 
     suspend fun makeSignUpRequest(accountAddress: Address): Transaction {

--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -1019,7 +1019,17 @@ public class WalletApplication extends BaseWalletApplication
             return FlowKt.emptyFlow();
         }
 
-        return new WalletTransactionObserver(wallet).observe(filters);
+        return new WalletTransactionObserver(wallet, false).observe(filters);
+    }
+
+    @NonNull
+    @Override
+    public Flow<Transaction> observeTransactionsWithConfidence(@NonNull TransactionFilter... filters) {
+        if (wallet == null) {
+            return FlowKt.emptyFlow();
+        }
+
+        return new WalletTransactionObserver(wallet, true).observe(filters);
     }
 
     @NonNull


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->
A listener in WalletTransactionObserver seemed to be the problem after doing analysis and many, many tests

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->
https://github.com/dashevo/dashj/pull/178
## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
