### PR TITLE
[NMA-1383] "You will receive" remains after reopen Convert Crypto

### DIFF
--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/ui/CoinbaseConvertCryptoFragment.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/ui/CoinbaseConvertCryptoFragment.kt
@@ -219,26 +219,28 @@ class CoinbaseConvertCryptoFragment : Fragment(R.layout.fragment_coinbase_conver
             setConvertViewInput()
         }
 
-        convertViewModel.enteredConvertDashAmount.observe(viewLifecycleOwner) { balance ->
-            val hasBalance = !balance.isZero
-            binding.youWillReceiveLabel.isVisible = hasBalance
-            binding.youWillReceiveValue.isVisible = hasBalance
-            if (hasBalance && !binding.convertView.dashToCrypto) {
+        convertViewModel.enteredConvertDashAmount.observe(viewLifecycleOwner) { amount ->
+            val hasAmount = !amount.isZero
+            binding.youWillReceiveLabel.isVisible = hasAmount
+            binding.youWillReceiveValue.isVisible = hasAmount
+
+            if (hasAmount && !binding.convertView.dashToCrypto) {
                 binding.youWillReceiveValue.text = context?.getString(
                     R.string.you_will_receive_dash,
-                    dashFormat.format(balance).toString()
+                    dashFormat.format(amount).toString()
                 )
             }
         }
 
-        convertViewModel.enteredConvertCryptoAmount.observe(viewLifecycleOwner) { balance ->
-            binding.youWillReceiveLabel.isVisible = balance.second.isNotEmpty()
-            binding.youWillReceiveValue.isVisible = balance.second.isNotEmpty()
+        convertViewModel.enteredConvertCryptoAmount.observe(viewLifecycleOwner) { amount ->
+            binding.youWillReceiveLabel.isVisible = amount.second.isNotEmpty()
+            binding.youWillReceiveValue.isVisible = amount.second.isNotEmpty()
+
             if (binding.convertView.dashToCrypto) {
                 binding.youWillReceiveValue.text = getString(
                     R.string.fiat_balance_with_currency,
-                    balance.first,
-                    GenericUtils.currencySymbol(balance.second)
+                    amount.first,
+                    GenericUtils.currencySymbol(amount.second)
                 )
             }
         }

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/viewmodels/ConvertViewViewModel.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/viewmodels/ConvertViewViewModel.kt
@@ -110,10 +110,6 @@ class ConvertViewViewModel @Inject constructor(
     val selectedLocalExchangeRate: LiveData<ExchangeRate>
         get() = _selectedLocalExchangeRate
 
-    private val _dashWalletBalance = MutableLiveData<Event<Coin>>()
-    val dashWalletBalance: LiveData<Event<Coin>>
-        get() = this._dashWalletBalance
-
     val userDashAccountEmptyError = SingleLiveEvent<Unit>()
 
     val validSwapValue = SingleLiveEvent<String>()
@@ -239,6 +235,8 @@ class ConvertViewViewModel @Inject constructor(
     fun clear() {
         _selectedCryptoCurrencyAccount.value = null
         _dashToCrypto.value = false
+        _enteredConvertDashAmount.value = Coin.ZERO
+        _enteredConvertCryptoAmount.value = Pair("", "")
     }
 
     fun continueSwap(pickedCurrencyOption: String) {
@@ -309,8 +307,6 @@ class ConvertViewViewModel @Inject constructor(
 
     private fun setDashWalletBalance() {
         val balance = walletDataProvider.getWalletBalance()
-        _dashWalletBalance.value = Event(balance)
-
         maxForDashWalletAmount = dashFormat.minDecimals(0)
             .optionalDecimals(0, 8).format(balance).toString()
     }


### PR DESCRIPTION
We need to clear entered dash/fiat amount from the shared viewModel after navigating back from the Convert Crypto fragment.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
